### PR TITLE
Add Hydra–Ophiucus unified warband asset transformation brief

### DIFF
--- a/hydra_warband_asset_transformation_brief.md
+++ b/hydra_warband_asset_transformation_brief.md
@@ -1,0 +1,112 @@
+# Hydra–Ophiucus Unified Warband: Asset Transformation Brief
+
+Use this brief to transform all uploaded reference images into a cohesive, dark-fantasy/sci-fantasy faction set.
+
+## Unified World Concept
+A merged warband forged from:
+- Followers of the Hydra
+- Cult of Ophiucus
+- Hydra Cultists
+- Knights of Ophiucus
+
+Visual motifs to blend across all pieces:
+- Triple-serpent sigil (three intertwined heads forming a halo)
+- Sacred geometric serpent circles
+- Cathedral-technology hybrid interiors
+- Ritual energy lattices, serpent runes, and bio-arcane armor
+
+## Faction Families (3)
+1. **Hydra Knights**
+   - Palette: cyber green, black, silver
+   - Role: elite armored crusaders, rune-lances, shield walls
+2. **Serpentine Paladines**
+   - Palette: silver, black, dark green
+   - Role: spell-sword nobility, duelist commanders, relic bearers
+3. **Fang Wardens / Coil Clergy**
+   - Palette: green, gold, neon yellow
+   - Role: zealot guardians, ritual casters, serpent architects
+
+## Five Leader Cards
+Create 5 unique leader-card assets (portrait + codex stat panel styling):
+
+1. **High Priestess of the Serpentine Flame**
+   - Regal ritual armor, serpent-flame halo, obsidian chapel background
+2. **Kundalini Ascendant**
+   - Floating battle-mystic with coiling luminous energy spine
+3. **Moon Serpent Oracle**
+   - Lunar glyph veil, silver-black robes, crescent runic staff
+4. **Shadow Serpent Architect**
+   - Arcane engineer with geometric serpent constructs
+5. **Triune Fang Marshal**
+   - War-leader merging knight, priest, and warden aesthetics
+
+Each card should include:
+- Nameplate
+- Faction marks (allied trinity icon + primary family icon)
+- 3 signature abilities
+- Rank/rarity strip
+- Lore blurb block
+
+## 30 Faction Codex Style Sheets (10 each faction)
+Build 30 codex page templates inspired by tactical dossiers and grim ritual records.
+
+### Hydra Knights (10)
+1. Order insignia sheet
+2. Unit hierarchy matrix
+3. Armor marks and helm variants
+4. Relic weapons index
+5. Battlefield doctrine spread
+6. Vehicle/construct silhouettes
+7. Oath liturgy page
+8. Command protocols
+9. Veteran honors and heraldry
+10. Campaign theater map overlay
+
+### Serpentine Paladines (10)
+1. Noble lineage chart
+2. Arcane martial disciplines
+3. Rite dueling forms
+4. Spellblade armory
+5. Sanctum architecture notes
+6. Officer portraits framework
+7. Tactical invocation wheel
+8. Sacred relic custody logs
+9. Diplomatic/intelligence profiles
+10. Exalted vows and penalties
+
+### Fang Wardens / Coil Clergy (10)
+1. Temple cell network map
+2. Ritual circle schematics
+3. Serpent totem taxonomy
+4. Warden beast-bond records
+5. High rite calendar
+6. Initiation progression chart
+7. Shadow operations grid
+8. Bio-arcane mutation notes
+9. Flame/venom doctrine sheet
+10. Apocalypse litany page
+
+## Composition Rules for Transforming Uploaded Assets
+- Preserve original composition silhouettes where feasible.
+- Replace existing faction insignia with tri-serpent/Ophiucus fusion marks.
+- Re-color by target faction palette while retaining cinematic contrast.
+- Add consistent UI frame language: metallic corners, rune separators, dossier typography.
+- Ensure all character costumes include at least 2 shared faction markers:
+  - serpent clasp
+  - triune sigil tabard
+  - scale-pattern inlay
+  - luminous ritual threading
+
+## Rendering Direction
+- Style: dark epic, high-detail concept-art + codex infographic hybrid
+- Lighting: cathedral gloom + neon ritual accents
+- Materials: brushed silver, obsidian leather, etched gold, emerald glow
+- Mood: militant devotion, occult hierarchy, controlled menace
+
+## Batch Prompt Skeleton (for image pipeline)
+"Transform the provided source image into the Hydra–Ophiucus Unified Warband aesthetic, preserving core pose and scene geometry. Integrate [TARGET FACTION] palette and iconography (tri-serpent sigil, ritual runes, gothic-tech architecture). Add codex-grade panel framing, lore UI accents, and cinematic volumetric lighting. Dark-fantasy sci-fantasy style, ultra-detailed, coherent armor language, no modern logos, no text artifacts."
+
+Use `[TARGET FACTION]` as one of:
+- Hydra Knights (cyber green / black / silver)
+- Serpentine Paladines (silver / black / dark green)
+- Fang Wardens & Coil Clergy (green / gold / neon yellow)


### PR DESCRIPTION
## Summary
- Adds `hydra_warband_asset_transformation_brief.md` with a complete art-direction package for transforming uploaded assets into a single fused Hydra–Ophiucus warband identity.
- Defines three faction families and palette systems:
  - Hydra Knights (cyber green/black/silver)
  - Serpentine Paladines (silver/black/dark green)
  - Fang Wardens & Coil Clergy (green/gold/neon yellow)
- Specifies five leader-card concepts and structure requirements.
- Specifies 30 codex style-sheet templates (10 per faction family).
- Includes composition, rendering, and batch prompt guidance to maintain consistency across transformed assets.

## Why
- Converts a broad creative request into an actionable, reusable production brief that can be executed in an image pipeline across all provided reference assets.

## Files
- `hydra_warband_asset_transformation_brief.md`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f566a77b2c832eb7c7d48e8d85cbcf)