### PR TITLE
Build Black Vault Console Phase 1 + Phase 2 command systems

### DIFF
--- a/api/black-vault-affiliate-matrix.js
+++ b/api/black-vault-affiliate-matrix.js
@@ -1,0 +1,60 @@
+const endpoint = (path) => `${process.env.SUPABASE_URL}/rest/v1/${path}`;
+
+async function readMatrix() {
+  if (!process.env.SUPABASE_URL || !process.env.SUPABASE_KEY) return [];
+  try {
+    const response = await fetch(endpoint('black_vault_affiliate_matrix?select=*&order=created_at.desc&limit=100'), {
+      headers: { apikey: process.env.SUPABASE_KEY },
+    });
+    if (!response.ok) return [];
+    const rows = await response.json();
+    return Array.isArray(rows) ? rows : [];
+  } catch {
+    return [];
+  }
+}
+
+async function insertMatrixRow(payload) {
+  if (!process.env.SUPABASE_URL || !process.env.SUPABASE_KEY) return null;
+  try {
+    const normalized = {
+      lane: payload.lane || 'Tracker Route',
+      source: payload.source || 'unknown',
+      cta: payload.cta || 'Tracked Link',
+      ctr: payload.ctr || null,
+      epc: payload.epc || null,
+      decision: payload.decision || 'Monitor',
+      tracking_url: payload.trackingUrl || payload.tracking_url || null,
+      metadata: payload.metadata || {},
+    };
+
+    const response = await fetch(endpoint('black_vault_affiliate_matrix'), {
+      method: 'POST',
+      headers: {
+        apikey: process.env.SUPABASE_KEY,
+        'Content-Type': 'application/json',
+        Prefer: 'return=representation',
+      },
+      body: JSON.stringify(normalized),
+    });
+    if (!response.ok) return null;
+    const rows = await response.json();
+    return Array.isArray(rows) ? rows[0] : null;
+  } catch {
+    return null;
+  }
+}
+
+export default async function handler(req, res) {
+  if (req.method === 'GET') {
+    return res.status(200).json({ matrix: await readMatrix() });
+  }
+
+  if (req.method === 'POST') {
+    const row = await insertMatrixRow(req.body || {});
+    return res.status(200).json({ row: row || req.body || null, persisted: Boolean(row) });
+  }
+
+  res.setHeader('Allow', 'GET, POST');
+  return res.status(405).json({ error: 'Method not allowed' });
+}

--- a/api/black-vault-dashboard.js
+++ b/api/black-vault-dashboard.js
@@ -1,0 +1,100 @@
+const fallback = {
+  metrics: [
+    { label: 'Active Offers', value: '18', tone: 'violet', delta: '+3 this week' },
+    { label: 'Live Warp Runs', value: '11', tone: 'emerald', delta: '7 running' },
+    { label: 'Age-Gated Pages', value: '42', tone: 'crimson', delta: '100% routed' },
+    { label: 'Affiliate EPC', value: '$2.74', tone: 'gold', delta: '+12.6%' },
+    { label: 'Vault CTR', value: '6.9%', tone: 'emerald', delta: '+0.8 pts' },
+    { label: 'Prompt Packs', value: '9', tone: 'violet', delta: '3 in review' },
+    { label: 'SEO Clusters', value: '27', tone: 'gold', delta: '4 refreshed' },
+    { label: 'Review Alerts', value: '2', tone: 'crimson', delta: 'Needs action' },
+  ],
+  offers: [],
+  matrix: [],
+  runs: [],
+  reviews: [],
+};
+
+const endpoint = (path) => `${process.env.SUPABASE_URL}/rest/v1/${path}`;
+
+async function fetchTable(path) {
+  if (!process.env.SUPABASE_URL || !process.env.SUPABASE_KEY) return [];
+  try {
+    const response = await fetch(endpoint(path), {
+      headers: { apikey: process.env.SUPABASE_KEY },
+    });
+    if (!response.ok) return [];
+    const rows = await response.json();
+    return Array.isArray(rows) ? rows : [];
+  } catch {
+    return [];
+  }
+}
+
+function countBy(rows, predicate) {
+  return rows.filter(predicate).length;
+}
+
+function currency(value) {
+  const amount = Number(value || 0);
+  return `$${amount.toFixed(2)}`;
+}
+
+function percent(value) {
+  const amount = Number(value || 0);
+  return `${amount.toFixed(1)}%`;
+}
+
+function deriveMetrics({ offers, matrix, runs, reviews }) {
+  if (!offers.length && !matrix.length && !runs.length && !reviews.length) return fallback.metrics;
+
+  const activeOffers = countBy(offers, (offer) => offer.status !== 'archived');
+  const runningRuns = countBy(runs, (run) => ['running', 'queued', 'review'].includes(String(run.status || '').toLowerCase()));
+  const gatedPages = countBy(offers, (offer) => offer.access_tier === 'age-gated' || offer.accessTier === 'age-gated');
+  const reviewAlerts = countBy(reviews, (review) => ['pending', 'needs-review', 'blocked'].includes(String(review.status || '').toLowerCase()));
+
+  const measurableRows = matrix.filter((row) => Number.isFinite(Number(row.epc_value ?? row.epcValue)));
+  const avgEpc = measurableRows.length
+    ? measurableRows.reduce((sum, row) => sum + Number(row.epc_value ?? row.epcValue ?? 0), 0) / measurableRows.length
+    : 0;
+
+  const ctrRows = matrix.filter((row) => Number.isFinite(Number(row.ctr_value ?? row.ctrValue)));
+  const avgCtr = ctrRows.length
+    ? ctrRows.reduce((sum, row) => sum + Number(row.ctr_value ?? row.ctrValue ?? 0), 0) / ctrRows.length
+    : 0;
+
+  return [
+    { label: 'Active Offers', value: String(activeOffers), tone: 'violet', delta: 'Live database' },
+    { label: 'Live Warp Runs', value: String(runningRuns), tone: 'emerald', delta: 'Run queue linked' },
+    { label: 'Age-Gated Pages', value: String(gatedPages), tone: 'crimson', delta: 'Route policy' },
+    { label: 'Affiliate EPC', value: currency(avgEpc), tone: 'gold', delta: 'Matrix average' },
+    { label: 'Vault CTR', value: percent(avgCtr), tone: 'emerald', delta: 'Matrix average' },
+    { label: 'Offer Objects', value: String(offers.length), tone: 'violet', delta: 'Editable' },
+    { label: 'Matrix Routes', value: String(matrix.length), tone: 'gold', delta: 'Tracker linked' },
+    { label: 'Review Alerts', value: String(reviewAlerts), tone: 'crimson', delta: 'Den Mother queue' },
+  ];
+}
+
+export default async function handler(req, res) {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const [offers, matrix, runs, reviews] = await Promise.all([
+    fetchTable('black_vault_offers?select=*&order=sort_order.asc,created_at.asc'),
+    fetchTable('black_vault_affiliate_matrix?select=*&order=created_at.desc&limit=50'),
+    fetchTable('black_vault_warp_runs?select=*&order=updated_at.desc&limit=20'),
+    fetchTable('black_vault_reviews?select=*&order=updated_at.desc&limit=20'),
+  ]);
+
+  const hasRemoteData = offers.length || matrix.length || runs.length || reviews.length;
+  return res.status(200).json({
+    metrics: deriveMetrics({ offers, matrix, runs, reviews }),
+    offers,
+    matrix,
+    runs,
+    reviews,
+    source: hasRemoteData ? 'supabase' : 'seed-fallback',
+  });
+}

--- a/api/black-vault-metric-snapshots.js
+++ b/api/black-vault-metric-snapshots.js
@@ -1,0 +1,60 @@
+const endpoint = (path) => `${process.env.SUPABASE_URL}/rest/v1/${path}`;
+
+async function readSnapshots() {
+  if (!process.env.SUPABASE_URL || !process.env.SUPABASE_KEY) return [];
+  try {
+    const response = await fetch(endpoint('black_vault_metric_snapshots?select=*&order=created_at.desc&limit=20'), {
+      headers: { apikey: process.env.SUPABASE_KEY },
+    });
+    if (!response.ok) return [];
+    const rows = await response.json();
+    return Array.isArray(rows) ? rows : [];
+  } catch {
+    return [];
+  }
+}
+
+async function insertSnapshot(payload = {}) {
+  if (!process.env.SUPABASE_URL || !process.env.SUPABASE_KEY) return null;
+  try {
+    const normalized = {
+      source: payload.source || 'black-vault-console',
+      metric_count: Array.isArray(payload.metrics) ? payload.metrics.length : 0,
+      metrics: Array.isArray(payload.metrics) ? payload.metrics : [],
+      offers_count: Number(payload.offersCount || payload.offers_count || 0),
+      matrix_count: Number(payload.matrixCount || payload.matrix_count || 0),
+      runs_count: Number(payload.runsCount || payload.runs_count || 0),
+      reviews_count: Number(payload.reviewsCount || payload.reviews_count || 0),
+      metadata: payload.metadata || {},
+    };
+
+    const response = await fetch(endpoint('black_vault_metric_snapshots'), {
+      method: 'POST',
+      headers: {
+        apikey: process.env.SUPABASE_KEY,
+        'Content-Type': 'application/json',
+        Prefer: 'return=representation',
+      },
+      body: JSON.stringify(normalized),
+    });
+    if (!response.ok) return null;
+    const rows = await response.json();
+    return Array.isArray(rows) ? rows[0] : null;
+  } catch {
+    return null;
+  }
+}
+
+export default async function handler(req, res) {
+  if (req.method === 'GET') {
+    return res.status(200).json({ snapshots: await readSnapshots() });
+  }
+
+  if (req.method === 'POST') {
+    const snapshot = await insertSnapshot(req.body || {});
+    return res.status(200).json({ snapshot: snapshot || req.body || null, persisted: Boolean(snapshot) });
+  }
+
+  res.setHeader('Allow', 'GET, POST');
+  return res.status(405).json({ error: 'Method not allowed' });
+}

--- a/api/black-vault-offers.js
+++ b/api/black-vault-offers.js
@@ -1,5 +1,25 @@
 const endpoint = (path) => `${process.env.SUPABASE_URL}/rest/v1/${path}`;
 
+function normalizeOfferPayload(payload = {}, { includeId = false } = {}) {
+  const normalized = {
+    tier: payload.tier || payload.offer_tier || 'Tier',
+    title: payload.title || 'Untitled Offer',
+    price: payload.price || payload.price_label || 'TBD',
+    purpose: payload.purpose || payload.description || '',
+    status: payload.status || 'active',
+    access_tier: payload.accessTier || payload.access_tier || 'age-gated',
+    sort_order: Number(payload.sortOrder ?? payload.sort_order ?? 100),
+    metadata: payload.metadata || {},
+    updated_at: new Date().toISOString(),
+  };
+
+  if (includeId && payload.id && !String(payload.id).startsWith('offer-')) {
+    normalized.id = payload.id;
+  }
+
+  return normalized;
+}
+
 async function readOffers() {
   if (!process.env.SUPABASE_URL || !process.env.SUPABASE_KEY) return [];
   try {
@@ -16,8 +36,8 @@ async function readOffers() {
 
 async function patchOffer(payload) {
   if (!process.env.SUPABASE_URL || !process.env.SUPABASE_KEY) return null;
-  const { id, ...fields } = payload || {};
-  if (!id) return null;
+  const id = payload?.id;
+  if (!id || String(id).startsWith('offer-')) return null;
 
   try {
     const response = await fetch(endpoint(`black_vault_offers?id=eq.${encodeURIComponent(id)}`), {
@@ -27,7 +47,7 @@ async function patchOffer(payload) {
         'Content-Type': 'application/json',
         Prefer: 'return=representation',
       },
-      body: JSON.stringify(fields),
+      body: JSON.stringify(normalizeOfferPayload(payload)),
     });
     if (!response.ok) return null;
     const rows = await response.json();
@@ -47,7 +67,7 @@ async function insertOffer(payload) {
         'Content-Type': 'application/json',
         Prefer: 'return=representation',
       },
-      body: JSON.stringify(payload),
+      body: JSON.stringify(normalizeOfferPayload(payload)),
     });
     if (!response.ok) return null;
     const rows = await response.json();
@@ -63,7 +83,8 @@ export default async function handler(req, res) {
   }
 
   if (req.method === 'PATCH') {
-    const offer = await patchOffer(req.body || {});
+    const patched = await patchOffer(req.body || {});
+    const offer = patched || await insertOffer(req.body || {});
     return res.status(200).json({ offer: offer || req.body || null, persisted: Boolean(offer) });
   }
 

--- a/api/black-vault-offers.js
+++ b/api/black-vault-offers.js
@@ -1,0 +1,77 @@
+const endpoint = (path) => `${process.env.SUPABASE_URL}/rest/v1/${path}`;
+
+async function readOffers() {
+  if (!process.env.SUPABASE_URL || !process.env.SUPABASE_KEY) return [];
+  try {
+    const response = await fetch(endpoint('black_vault_offers?select=*&order=sort_order.asc,created_at.asc'), {
+      headers: { apikey: process.env.SUPABASE_KEY },
+    });
+    if (!response.ok) return [];
+    const rows = await response.json();
+    return Array.isArray(rows) ? rows : [];
+  } catch {
+    return [];
+  }
+}
+
+async function patchOffer(payload) {
+  if (!process.env.SUPABASE_URL || !process.env.SUPABASE_KEY) return null;
+  const { id, ...fields } = payload || {};
+  if (!id) return null;
+
+  try {
+    const response = await fetch(endpoint(`black_vault_offers?id=eq.${encodeURIComponent(id)}`), {
+      method: 'PATCH',
+      headers: {
+        apikey: process.env.SUPABASE_KEY,
+        'Content-Type': 'application/json',
+        Prefer: 'return=representation',
+      },
+      body: JSON.stringify(fields),
+    });
+    if (!response.ok) return null;
+    const rows = await response.json();
+    return Array.isArray(rows) ? rows[0] : null;
+  } catch {
+    return null;
+  }
+}
+
+async function insertOffer(payload) {
+  if (!process.env.SUPABASE_URL || !process.env.SUPABASE_KEY) return null;
+  try {
+    const response = await fetch(endpoint('black_vault_offers'), {
+      method: 'POST',
+      headers: {
+        apikey: process.env.SUPABASE_KEY,
+        'Content-Type': 'application/json',
+        Prefer: 'return=representation',
+      },
+      body: JSON.stringify(payload),
+    });
+    if (!response.ok) return null;
+    const rows = await response.json();
+    return Array.isArray(rows) ? rows[0] : null;
+  } catch {
+    return null;
+  }
+}
+
+export default async function handler(req, res) {
+  if (req.method === 'GET') {
+    return res.status(200).json({ offers: await readOffers() });
+  }
+
+  if (req.method === 'PATCH') {
+    const offer = await patchOffer(req.body || {});
+    return res.status(200).json({ offer: offer || req.body || null, persisted: Boolean(offer) });
+  }
+
+  if (req.method === 'POST') {
+    const offer = await insertOffer(req.body || {});
+    return res.status(200).json({ offer: offer || req.body || null, persisted: Boolean(offer) });
+  }
+
+  res.setHeader('Allow', 'GET, PATCH, POST');
+  return res.status(405).json({ error: 'Method not allowed' });
+}

--- a/api/black-vault-reviews.js
+++ b/api/black-vault-reviews.js
@@ -1,0 +1,96 @@
+const endpoint = (path) => `${process.env.SUPABASE_URL}/rest/v1/${path}`;
+
+async function readReviews() {
+  if (!process.env.SUPABASE_URL || !process.env.SUPABASE_KEY) return [];
+  try {
+    const response = await fetch(endpoint('black_vault_reviews?select=*&order=updated_at.desc,created_at.desc&limit=100'), {
+      headers: { apikey: process.env.SUPABASE_KEY },
+    });
+    if (!response.ok) return [];
+    const rows = await response.json();
+    return Array.isArray(rows) ? rows : [];
+  } catch {
+    return [];
+  }
+}
+
+async function insertReview(payload) {
+  if (!process.env.SUPABASE_URL || !process.env.SUPABASE_KEY) return null;
+  try {
+    const normalized = {
+      title: payload.title || 'Untitled Review Item',
+      type: payload.type || 'Vault Review',
+      status: payload.status || 'Needs Review',
+      risk: payload.risk || 'Medium',
+      owner: payload.owner || 'Den Mother',
+      notes: payload.notes || null,
+      metadata: payload.metadata || {},
+      updated_at: new Date().toISOString(),
+    };
+
+    const response = await fetch(endpoint('black_vault_reviews'), {
+      method: 'POST',
+      headers: {
+        apikey: process.env.SUPABASE_KEY,
+        'Content-Type': 'application/json',
+        Prefer: 'return=representation',
+      },
+      body: JSON.stringify(normalized),
+    });
+    if (!response.ok) return null;
+    const rows = await response.json();
+    return Array.isArray(rows) ? rows[0] : null;
+  } catch {
+    return null;
+  }
+}
+
+async function patchReview(payload) {
+  if (!process.env.SUPABASE_URL || !process.env.SUPABASE_KEY) return null;
+  if (!payload?.id) return null;
+
+  try {
+    const fields = {
+      status: payload.status,
+      risk: payload.risk,
+      notes: payload.notes,
+      updated_at: new Date().toISOString(),
+    };
+
+    Object.keys(fields).forEach((key) => fields[key] === undefined && delete fields[key]);
+
+    const response = await fetch(endpoint(`black_vault_reviews?id=eq.${encodeURIComponent(payload.id)}`), {
+      method: 'PATCH',
+      headers: {
+        apikey: process.env.SUPABASE_KEY,
+        'Content-Type': 'application/json',
+        Prefer: 'return=representation',
+      },
+      body: JSON.stringify(fields),
+    });
+    if (!response.ok) return null;
+    const rows = await response.json();
+    return Array.isArray(rows) ? rows[0] : null;
+  } catch {
+    return null;
+  }
+}
+
+export default async function handler(req, res) {
+  if (req.method === 'GET') {
+    return res.status(200).json({ reviews: await readReviews() });
+  }
+
+  if (req.method === 'POST') {
+    const review = await insertReview(req.body || {});
+    return res.status(200).json({ review: review || req.body || null, persisted: Boolean(review) });
+  }
+
+  if (req.method === 'PATCH') {
+    const review = await patchReview(req.body || {});
+    return res.status(200).json({ review: review || req.body || null, persisted: Boolean(review) });
+  }
+
+  res.setHeader('Allow', 'GET, POST, PATCH');
+  return res.status(405).json({ error: 'Method not allowed' });
+}

--- a/api/black-vault-run-events.js
+++ b/api/black-vault-run-events.js
@@ -1,0 +1,83 @@
+const endpoint = (path) => `${process.env.SUPABASE_URL}/rest/v1/${path}`;
+
+async function recordHydraEvent(payload) {
+  if (!process.env.SUPABASE_URL || !process.env.SUPABASE_KEY) return null;
+  try {
+    const response = await fetch(endpoint('hydra_events'), {
+      method: 'POST',
+      headers: {
+        apikey: process.env.SUPABASE_KEY,
+        'Content-Type': 'application/json',
+        Prefer: 'return=representation',
+      },
+      body: JSON.stringify({
+        type: 'black_vault_warp_run_event',
+        value: Number(payload.progress || 0),
+        metadata: {
+          run: payload.run,
+          task: payload.task,
+          status: payload.status,
+          external_ref: payload.externalRef || payload.external_ref || null,
+          event_source: payload.eventSource || payload.event_source || 'warp',
+          details: payload.metadata || {},
+        },
+      }),
+    });
+    if (!response.ok) return null;
+    const rows = await response.json();
+    return Array.isArray(rows) ? rows[0] : null;
+  } catch {
+    return null;
+  }
+}
+
+async function persistRun(payload) {
+  if (!process.env.SUPABASE_URL || !process.env.SUPABASE_KEY) return null;
+  try {
+    const normalized = {
+      run: payload.run || payload.run_id || `Warp-VA-${Date.now()}`,
+      task: payload.task || 'External run event',
+      status: payload.status || 'Running',
+      progress: Number(payload.progress || 0),
+      external_ref: payload.externalRef || payload.external_ref || null,
+      event_source: payload.eventSource || payload.event_source || 'warp',
+      metadata: payload.metadata || {},
+      updated_at: new Date().toISOString(),
+    };
+
+    const response = await fetch(endpoint('black_vault_warp_runs'), {
+      method: 'POST',
+      headers: {
+        apikey: process.env.SUPABASE_KEY,
+        'Content-Type': 'application/json',
+        Prefer: 'return=representation',
+      },
+      body: JSON.stringify(normalized),
+    });
+    if (!response.ok) return null;
+    const rows = await response.json();
+    return Array.isArray(rows) ? rows[0] : null;
+  } catch {
+    return null;
+  }
+}
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const payload = req.body || {};
+  const [event, run] = await Promise.all([
+    recordHydraEvent(payload),
+    persistRun(payload),
+  ]);
+
+  return res.status(200).json({
+    accepted: true,
+    persisted: Boolean(event || run),
+    event,
+    run,
+  });
+}

--- a/api/black-vault-warp-runs.js
+++ b/api/black-vault-warp-runs.js
@@ -1,0 +1,95 @@
+const endpoint = (path) => `${process.env.SUPABASE_URL}/rest/v1/${path}`;
+
+async function readRuns() {
+  if (!process.env.SUPABASE_URL || !process.env.SUPABASE_KEY) return [];
+  try {
+    const response = await fetch(endpoint('black_vault_warp_runs?select=*&order=updated_at.desc&limit=50'), {
+      headers: { apikey: process.env.SUPABASE_KEY },
+    });
+    if (!response.ok) return [];
+    const rows = await response.json();
+    return Array.isArray(rows) ? rows : [];
+  } catch {
+    return [];
+  }
+}
+
+async function insertRun(payload) {
+  if (!process.env.SUPABASE_URL || !process.env.SUPABASE_KEY) return null;
+  try {
+    const normalized = {
+      run: payload.run || payload.run_id || `Warp-VA-${Date.now()}`,
+      task: payload.task || 'Unlabeled run',
+      status: payload.status || 'Queued',
+      progress: Number(payload.progress || 0),
+      external_ref: payload.externalRef || payload.external_ref || null,
+      event_source: payload.eventSource || payload.event_source || 'manual',
+      metadata: payload.metadata || {},
+      updated_at: new Date().toISOString(),
+    };
+
+    const response = await fetch(endpoint('black_vault_warp_runs'), {
+      method: 'POST',
+      headers: {
+        apikey: process.env.SUPABASE_KEY,
+        'Content-Type': 'application/json',
+        Prefer: 'return=representation',
+      },
+      body: JSON.stringify(normalized),
+    });
+    if (!response.ok) return null;
+    const rows = await response.json();
+    return Array.isArray(rows) ? rows[0] : null;
+  } catch {
+    return null;
+  }
+}
+
+async function patchRun(payload) {
+  if (!process.env.SUPABASE_URL || !process.env.SUPABASE_KEY) return null;
+  const id = payload.id;
+  if (!id) return null;
+
+  try {
+    const fields = {
+      status: payload.status,
+      progress: Number(payload.progress ?? 0),
+      metadata: payload.metadata || {},
+      updated_at: new Date().toISOString(),
+    };
+
+    const response = await fetch(endpoint(`black_vault_warp_runs?id=eq.${encodeURIComponent(id)}`), {
+      method: 'PATCH',
+      headers: {
+        apikey: process.env.SUPABASE_KEY,
+        'Content-Type': 'application/json',
+        Prefer: 'return=representation',
+      },
+      body: JSON.stringify(fields),
+    });
+    if (!response.ok) return null;
+    const rows = await response.json();
+    return Array.isArray(rows) ? rows[0] : null;
+  } catch {
+    return null;
+  }
+}
+
+export default async function handler(req, res) {
+  if (req.method === 'GET') {
+    return res.status(200).json({ runs: await readRuns() });
+  }
+
+  if (req.method === 'POST') {
+    const run = await insertRun(req.body || {});
+    return res.status(200).json({ run: run || req.body || null, persisted: Boolean(run) });
+  }
+
+  if (req.method === 'PATCH') {
+    const run = await patchRun(req.body || {});
+    return res.status(200).json({ run: run || req.body || null, persisted: Boolean(run) });
+  }
+
+  res.setHeader('Allow', 'GET, POST, PATCH');
+  return res.status(405).json({ error: 'Method not allowed' });
+}

--- a/api/black-vault-warp-sync.js
+++ b/api/black-vault-warp-sync.js
@@ -1,0 +1,89 @@
+const endpoint = (path) => `${process.env.SUPABASE_URL}/rest/v1/${path}`;
+
+function asArray(payload) {
+  if (Array.isArray(payload)) return payload;
+  if (Array.isArray(payload?.runs)) return payload.runs;
+  if (Array.isArray(payload?.data)) return payload.data;
+  if (Array.isArray(payload?.items)) return payload.items;
+  return [];
+}
+
+function normalizeWarpRun(run, index) {
+  const rawStatus = String(run.status || run.state || run.phase || 'Queued');
+  const progress = Number(run.progress ?? run.percent_complete ?? run.percentComplete ?? run.completion ?? 0);
+  return {
+    run: run.run || run.id || run.run_id || run.thread_id || `Warp-Sync-${index + 1}`,
+    task: run.task || run.title || run.name || run.goal || 'Warp execution run',
+    status: rawStatus,
+    progress: Number.isFinite(progress) ? Math.max(0, Math.min(100, progress)) : 0,
+    external_ref: run.external_ref || run.externalRef || run.id || run.run_id || null,
+    event_source: 'warp-sync',
+    metadata: {
+      sourcePayload: run,
+      syncedAt: new Date().toISOString(),
+    },
+    updated_at: new Date().toISOString(),
+  };
+}
+
+async function fetchWarpRuns() {
+  const runsEndpoint = process.env.WARP_RUNS_ENDPOINT;
+  const warpApiKey = process.env.WARP_API_KEY;
+  const warpBearerToken = process.env.WARP_BEARER_TOKEN;
+
+  if (!runsEndpoint) {
+    return { runs: [], source: 'not-configured', error: 'WARP_RUNS_ENDPOINT is not configured.' };
+  }
+
+  const headers = { Accept: 'application/json' };
+  if (warpBearerToken) headers.Authorization = `Bearer ${warpBearerToken}`;
+  if (warpApiKey) headers['x-api-key'] = warpApiKey;
+
+  try {
+    const response = await fetch(runsEndpoint, { headers });
+    const payload = await response.json();
+    if (!response.ok) {
+      return { runs: [], source: 'warp-endpoint', error: payload?.error || `Warp endpoint returned ${response.status}.` };
+    }
+    return { runs: asArray(payload).map(normalizeWarpRun), source: 'warp-endpoint', error: null };
+  } catch (error) {
+    return { runs: [], source: 'warp-endpoint', error: error?.message || 'Warp sync request failed.' };
+  }
+}
+
+async function persistRuns(runs) {
+  if (!runs.length || !process.env.SUPABASE_URL || !process.env.SUPABASE_KEY) return [];
+  try {
+    const response = await fetch(endpoint('black_vault_warp_runs'), {
+      method: 'POST',
+      headers: {
+        apikey: process.env.SUPABASE_KEY,
+        'Content-Type': 'application/json',
+        Prefer: 'return=representation',
+      },
+      body: JSON.stringify(runs),
+    });
+    if (!response.ok) return [];
+    const rows = await response.json();
+    return Array.isArray(rows) ? rows : [];
+  } catch {
+    return [];
+  }
+}
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const sync = await fetchWarpRuns();
+  const persistedRows = await persistRuns(sync.runs);
+
+  return res.status(200).json({
+    runs: persistedRows.length ? persistedRows : sync.runs,
+    persisted: Boolean(persistedRows.length),
+    source: sync.source,
+    error: sync.error,
+  });
+}

--- a/docs/black-vault/black-vault-phase-2-build-report.md
+++ b/docs/black-vault/black-vault-phase-2-build-report.md
@@ -1,0 +1,174 @@
+# Black Vault Console — Phase 2 Build Report
+
+## Status
+
+**Phase 2 is implemented on branch:** `hydra-creator-priority-build`
+
+This build converts the Black Vault Console from a static command deck into a persistence-aware operating surface with API bridges, review queue integration, tracker-to-matrix routing, editable offers, and run synchronization adapters.
+
+---
+
+## Phase 2 Objectives Completed
+
+### 1. Persist console metrics to database-backed analytics
+Implemented:
+
+- `api/black-vault-dashboard.js`
+- `api/black-vault-metric-snapshots.js`
+- `omega-hydra-app/supabase/black-vault-phase-2.sql`
+- Frontend metric snapshot controls in `BlackVaultConsole.jsx`
+
+The console now supports:
+
+- API-derived dashboard metrics
+- Metrics computed from offers, matrix rows, runs, and review records
+- Manual metric snapshot persistence for history and future trend views
+
+---
+
+### 2. Link live Warp job events into the run center
+Implemented:
+
+- `api/black-vault-run-events.js`
+- `api/black-vault-warp-runs.js`
+- `api/black-vault-warp-sync.js`
+- Frontend `Sync Warp Runs` control in `BlackVaultConsole.jsx`
+
+The console now supports:
+
+- Event intake for external run status payloads
+- Persistence of run queue records
+- A configurable sync adapter using environment variables rather than a hard-wired endpoint
+
+### Required environment variables for sync adapter
+
+```text
+WARP_RUNS_ENDPOINT=
+WARP_API_KEY=
+WARP_BEARER_TOKEN=
+```
+
+Only `WARP_RUNS_ENDPOINT` is required for the adapter to attempt a remote sync. The key/token variables are optional depending on the remote endpoint.
+
+---
+
+### 3. Connect Affiliate Tracker outputs into the Affiliate Matrix
+Implemented:
+
+- `submitAffiliateMatrixRoute()` in `blackVaultService.js`
+- New `Send to Black Vault Matrix` action in `AffiliateTracker.jsx`
+- `api/black-vault-affiliate-matrix.js`
+- Console refresh event: `hydra:black-vault:matrix-updated`
+
+Tracker-generated routes can now move directly into the Black Vault affiliate matrix and appear in the command console after submission.
+
+---
+
+### 4. Convert offer ladder cards into editable commercial objects
+Implemented:
+
+- Editable Offer Ladder cards in `BlackVaultConsole.jsx`
+- `saveBlackVaultOffer()` frontend service helper
+- `api/black-vault-offers.js`
+- Supabase table: `black_vault_offers`
+
+The console now supports title, price, and purpose edits with:
+
+- Local fallback persistence
+- API persistence when storage is configured
+- Automatic insert fallback if a seed offer does not yet exist in storage
+
+---
+
+### 5. Add Den Mother review queue integration with Compliance Center
+Implemented:
+
+- `api/black-vault-reviews.js`
+- `fetchBlackVaultReviews()` and `updateBlackVaultReviewStatus()`
+- Review metrics in `ComplianceCenter.jsx`
+- Approve / Needs Review / Block actions
+- Supabase table: `black_vault_reviews`
+
+Compliance Center now functions as the review command point for the Black Vault branch while preserving the public/private boundary doctrine.
+
+---
+
+## New Persistence Tables
+
+Phase 2 schema now defines:
+
+1. `black_vault_offers`
+2. `black_vault_affiliate_matrix`
+3. `black_vault_warp_runs`
+4. `black_vault_reviews`
+5. `black_vault_metric_snapshots`
+
+Schema path:
+
+```text
+omega-hydra-app/supabase/black-vault-phase-2.sql
+```
+
+---
+
+## Backend API Surface Added
+
+| Endpoint | Purpose |
+| --- | --- |
+| `/api/black-vault-dashboard` | Aggregated console payload |
+| `/api/black-vault-offers` | Offer reads + edits |
+| `/api/black-vault-affiliate-matrix` | Matrix reads + route submission |
+| `/api/black-vault-warp-runs` | Run reads + manual persistence |
+| `/api/black-vault-run-events` | External run event intake |
+| `/api/black-vault-warp-sync` | Configurable remote sync adapter |
+| `/api/black-vault-reviews` | Den Mother review queue |
+| `/api/black-vault-metric-snapshots` | Persist metric snapshots |
+
+---
+
+## Frontend Modules Updated
+
+| File | Upgrade |
+| --- | --- |
+| `BlackVaultConsole.jsx` | API hydration, editable offers, Warp sync, metric snapshots |
+| `AffiliateTracker.jsx` | Tracker-to-matrix submission |
+| `ComplianceCenter.jsx` | Review queue hydration and status actions |
+| `blackVaultService.js` | Service layer across dashboard, offers, matrix, reviews, sync, snapshots |
+
+---
+
+## CEO Logic Completion Ruling
+
+Phase 2 has reached **build-complete / integration-ready** status.
+
+### What is complete
+- UI support
+- Service bridge
+- API routes
+- Persistence schema
+- Local fallback states
+- Editable commerce objects
+- Review queue actions
+- Matrix submission rail
+- Run sync adapter
+- Metric snapshots
+
+### What still requires deployment configuration
+- Apply the Supabase SQL schema
+- Configure `SUPABASE_URL` and `SUPABASE_KEY`
+- Configure `WARP_RUNS_ENDPOINT` if live remote run syncing is desired
+- Deploy the branch or merge the PR after review
+
+---
+
+## Phase 3 Suggested Next Move
+
+**Context Orbit × Black Vault linking**
+
+Link:
+
+```text
+Offer → Tracking Route → Matrix Row → Warp Run → Review Decision → Snapshot
+```
+
+This would make the Black Vault branch visible inside the larger Hydra Context Orbit intelligence fabric rather than only inside its local command deck.

--- a/docs/black-vault/velvet-grin-black-vault-console-command-deck.md
+++ b/docs/black-vault/velvet-grin-black-vault-console-command-deck.md
@@ -1,0 +1,156 @@
+# Velvet Grin Black Vault Console Command Deck
+
+## Canonical System Identity
+
+**Warp.dev Limitless × Omega Hydra Jezebel Velvet Black Vault Console** is the private, age-gated command deck for mature affiliate strategy, fictional media planning, vault discipline, and revenue intelligence.
+
+It is deliberately separated from the public-safe Crown Order / Shadow Monastery creator branch.
+
+---
+
+## Command Equation
+
+```text
+Warp.dev Limitless
++ Omega Hydra CEO Logic
++ Jezebel Velvet Conversion Studio
++ Black Grin Revenue Intelligence
++ Den Mother Vault Governance
+= Velvet Grin Black Vault Console
+```
+
+---
+
+## Purpose
+
+The Black Vault Console is a gated operating surface for:
+
+- Affiliate offer ranking
+- SEO / blog cluster control
+- SubID attribution logic
+- Prompt pack commercialization
+- Mature fictional asset planning
+- Public/private boundary discipline
+- Offer ladder monitoring
+- Warp automation queue visibility
+- CEO scale / refine / monitor decisions
+
+---
+
+## Command Council
+
+| Command Layer | Function |
+| --- | --- |
+| **Jezebel Velvet** | Offer presentation, premium packaging, editorial magnetism |
+| **Black Grin** | CTR, EPC, funnel optimization, revenue intelligence |
+| **Den Mother** | Age-gate checks, vault boundaries, review discipline |
+| **CEO Logic** | Final approval, evidence gates, hold/refine/scale decisions |
+
+---
+
+## Console Modules
+
+### 1. Executive Metric Rail
+Tracks:
+
+- Active offers
+- Live Warp runs
+- Age-gated routes
+- EPC
+- CTR
+- Prompt packs
+- SEO clusters
+- Review alerts
+
+### 2. Offer Ladder
+Tracks the private monetization path:
+
+```text
+Free Teaser
+→ $9 Prompt Starter
+→ $27 Founder Pack
+→ $97 Affiliate Matrix Kit
+→ $197 Black Vault Console System
+```
+
+### 3. Velvet Affiliate Matrix
+A performance grid for:
+
+- Review hubs
+- Alternatives clusters
+- Vault email upsells
+- Social profile routes
+- CTR / EPC / CTA posture
+- CEO Logic decisions
+
+### 4. Warp Limitless Run Center
+Monitors:
+
+- Offer matrix refresh
+- Vault metadata tagging
+- Quarterly SEO refresh
+- Affiliate SubID rollups
+- Landing-page variant packs
+
+### 5. Mature Media Visualizer Stack
+Private fictional IP planning only:
+
+- Persona moodboards
+- Scene pack catalogs
+- Prompt Vault tags
+- Public/private split controls
+
+### 6. Python Head Swarm
+Specialized heads:
+
+- Vault Governance Python
+- Affiliate Matrix Python
+- Visualizer Stack Python
+- Offer Ladder Python
+- SubID Attribution Python
+- SEO Refresh Python
+- Disclosure Audit Python
+- CEO Decision Python
+
+---
+
+## Build Location
+
+```text
+omega-hydra-app/src/components/tabs/BlackVaultConsole.jsx
+omega-hydra-app/src/data/blackVaultConsole.js
+```
+
+The console is registered in:
+
+```text
+omega-hydra-app/src/App.jsx
+omega-hydra-app/src/components/Sidebar.jsx
+```
+
+---
+
+## Guardrails
+
+The Black Vault Console may manage adult-affiliate business operations and mature fictional IP strategy, but it must preserve these system boundaries:
+
+1. Public-safe Hydra content remains separate.
+2. Age-gated destinations remain explicitly routed.
+3. Affiliate disclosures remain visible.
+4. No real-world service promotion is blended into fictional brand content.
+5. CEO Logic must reject hype claims and unverifiable income guarantees.
+6. Den Mother review is required for public/private boundary concerns.
+
+---
+
+## Canonical Release State
+
+**Status:** Built as an app tab and data-backed command surface on the `hydra-creator-priority-build` branch.
+
+**Next direct build layers:**
+
+1. Persist Black Vault metrics to database-backed analytics.
+2. Link Warp job events to live run feeds.
+3. Connect SubID tracker outputs into affiliate matrix rows.
+4. Convert offer ladder cards into editable commercial objects.
+5. Add Den Mother review queue integration with Compliance Center.

--- a/docs/build/hydra-creator-priority-buildout.md
+++ b/docs/build/hydra-creator-priority-buildout.md
@@ -1,0 +1,132 @@
+# Hydra Creator Priority Buildout
+
+## Canonical Priority Order
+
+1. **Hydra Creator App frontend scaffold**
+2. **Hydra Context Orbit persistence graph**
+3. **Harness profiles + Warp job linkage**
+4. **Hydra SkillForge product modules**
+5. **Autonomous Spectacle proof loop**
+6. **Commercial bridge completion**
+
+This file formalizes the priority path for the Omega Hydra build queue and converts the previous master architecture into a completion-oriented execution doctrine.
+
+---
+
+## Command Structure
+
+### Obsidian Captain Nyssa — General Manager
+Nyssa owns operational sequencing, dependency control, and build coherence. Her responsibility is to keep the six-track build order moving as one connected system rather than six disconnected experiments.
+
+### Malvoth the Red Knight — Automation Marshal
+Malvoth owns task decomposition, Python-head generation, queue discipline, repetitive implementation logic, and escalation of blocked work. His output is structured build orders, machine-readable manifests, and automation-ready task packets.
+
+### CEO Logic — Final Decision Layer
+CEO Logic arbitrates priority conflicts, validates release readiness, and decides whether a subsystem should:
+
+- **Scale**
+- **Refine**
+- **Hold**
+- **Kill / Re-scope**
+
+Final shipping decisions should be made against completion evidence rather than enthusiasm alone.
+
+---
+
+## Six Priority Tracks
+
+### 1. Hydra Creator App Frontend Scaffold
+**Objective:** Deliver the operator-facing shell for the Hydra Creator terminal.
+
+**Completion criteria:**
+- Route-ready command center
+- Creator cockpit dashboard
+- Persona testing access point
+- Vault, Conclave, Warp, and Orbit entry paths
+- Shared metric cards, build status cards, and escalation indicators
+
+### 2. Context Orbit Persistence Graph
+**Objective:** Establish the intelligence fabric that persists relationships between personas, projects, assets, reviews, workflows, and execution jobs.
+
+**Completion criteria:**
+- Node and edge categories defined
+- Priority graph lanes visualized in UI
+- Data contracts ready for Supabase/Postgres implementation
+- Graph can explain `what produced what` and `what is blocked by what`
+
+### 3. Harness Profiles + Warp Job Linkage
+**Objective:** Convert agent execution into a governed, inspectable system.
+
+**Completion criteria:**
+- Harness profile fields documented
+- Warp-linked job states displayed
+- Autonomy ceilings, verifier rules, and rollback rules visible
+- Execution jobs can be categorized by build track
+
+### 4. Hydra SkillForge Product Modules
+**Objective:** Productize repeatable workflows as modular offers.
+
+**Completion criteria:**
+- Skill pack categories defined
+- Starter product catalog surfaced in app
+- Build-track workflows mapped to sellable modules
+- Course, prompt, and workflow bundle lanes identified
+
+### 5. Autonomous Spectacle Proof Loop
+**Objective:** Turn visible system execution into public proof-media and internal telemetry.
+
+**Completion criteria:**
+- Proof-stream tiles defined
+- What-to-show / what-not-to-show boundaries documented
+- Metrics for run count, asset count, review state, and build velocity surfaced
+- Dashboard can support public-safe spectacle framing
+
+### 6. Commercial Bridge Completion
+**Objective:** Close the loop from content → offer → fulfillment → analytics.
+
+**Completion criteria:**
+- Offer ladder represented
+- Fulfillment rail mapped
+- Product delivery states shown
+- KPI bridge from audience signal to revenue signal identified
+
+---
+
+## Python Head Swarm
+
+The initial build swarm should be represented by specialized Python heads:
+
+1. **Frontend Scaffold Python** — routes, shell, UI modules
+2. **Orbit Graph Python** — nodes, edges, dependency mapping
+3. **Harness Guard Python** — permissions, verifier rules, rollback policy
+4. **Warp Dispatch Python** — execution queue, job-state modeling
+5. **SkillForge Python** — product modules, offers, bundles
+6. **Spectacle Python** — proof-media telemetry and dashboard feeds
+7. **Commerce Bridge Python** — offers, checkout, delivery, analytics
+8. **Nyssa PM Python** — dependency and priority tracking
+9. **Malvoth Automation Python** — task decomposition and manifest generation
+10. **CEO Adjudicator Python** — final release status and decision gates
+
+---
+
+## CEO Decision Rules
+
+| Condition | Decision |
+| --- | --- |
+| High dependency risk, incomplete data contracts | Hold and complete Context Orbit first |
+| UI exists without persistence contracts | Refine, do not declare complete |
+| Product module exists without fulfillment bridge | Hold from release |
+| Automation exists without review/rollback | Re-scope before deployment |
+| Feature reduces build friction and compounds future output | Scale |
+
+---
+
+## Immediate Release Principle
+
+> **No track is considered complete merely because it has a concept document. A track is complete only when it has a visible interface, a data contract, and a clear next execution path.**
+
+---
+
+## Current Build Target
+
+The current repository target is to establish the first production-grade command surface inside `omega-hydra-app` while preserving compatibility with the existing Omega Hydra ecosystem.

--- a/omega-hydra-app/src/App.jsx
+++ b/omega-hydra-app/src/App.jsx
@@ -14,11 +14,13 @@ import ComplianceCenter from './components/tabs/ComplianceCenter';
 import CEOPythons from './components/tabs/CEOPythons';
 import EvolutionScanner from './components/tabs/EvolutionScanner';
 import Realm5Crowns from './components/tabs/Realm5Crowns';
+import BlackVaultConsole from './components/tabs/BlackVaultConsole';
 
 const tabComponents = {
   dashboard: Dashboard,
   sfw: SFWPipeline,
   adult: AdultPipeline,
+  blackvault: BlackVaultConsole,
   characters: CharacterFactory,
   drops: DailyDropEngine,
   books: BookForge,

--- a/omega-hydra-app/src/components/Sidebar.jsx
+++ b/omega-hydra-app/src/components/Sidebar.jsx
@@ -2,6 +2,7 @@ const NAV_ITEMS = [
   { id: 'dashboard', label: 'Dashboard', icon: '⬡' },
   { id: 'sfw', label: 'SFW Pipeline', icon: '🌿' },
   { id: 'adult', label: '18+ Pipeline', icon: '🔒' },
+  { id: 'blackvault', label: 'Black Vault Console', icon: '🗝' },
   { id: 'characters', label: 'Character Factory', icon: '👁' },
   { id: 'drops', label: 'Daily Drops', icon: '🔥' },
   { id: 'books', label: 'Book Forge', icon: '📖' },

--- a/omega-hydra-app/src/components/tabs/AffiliateTracker.jsx
+++ b/omega-hydra-app/src/components/tabs/AffiliateTracker.jsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, useMemo } from 'react';
 import { ingestTrackingUrl } from '../../utils/urlIngest';
 import { SAMPLE_BING_INGEST_URL } from '../../constants/urlSamples';
+import { submitAffiliateMatrixRoute } from '../../services/blackVaultService';
 
 const sampleStats = [
   { subid: 'velrya-tiktok-bio-shadow-v1', clicks: 312, epc: '$2.87', revenue: '$143.54', lastActive: '2h ago' },
@@ -20,6 +21,8 @@ export default function AffiliateTracker() {
   });
   const [rawIngestUrl, setRawIngestUrl] = useState(SAMPLE_BING_INGEST_URL);
   const [copiedTarget, setCopiedTarget] = useState(null);
+  const [matrixState, setMatrixState] = useState(null);
+  const [isSubmittingMatrix, setIsSubmittingMatrix] = useState(false);
 
   const set = (k, v) => setForm(f => ({ ...f, [k]: v }));
   const ingestedLink = useMemo(() => ingestTrackingUrl(rawIngestUrl), [rawIngestUrl]);
@@ -65,11 +68,37 @@ export default function AffiliateTracker() {
     }
   }, [ingestedLink.destinationUrl]);
 
+  const handleSendToMatrix = useCallback(async () => {
+    setIsSubmittingMatrix(true);
+    setMatrixState(null);
+    const result = await submitAffiliateMatrixRoute({
+      lane: `${form.sub1 || 'hydra'} / ${form.sub4 || 'campaign'}`,
+      source: form.sub2 || ingestedLink.sourceHost || 'unknown',
+      cta: `${form.sub3 || 'placement'} route`,
+      decision: 'Monitor',
+      trackingUrl: fullUrl,
+      metadata: {
+        sub1: form.sub1,
+        sub2: form.sub2,
+        sub3: form.sub3,
+        sub4: form.sub4,
+        sub5: form.sub5,
+        destinationUrl: ingestedLink.destinationUrl || null,
+        sourceHost: ingestedLink.sourceHost || null,
+        destinationHost: ingestedLink.destinationHost || null,
+        extractedMetadata: ingestedLink.metadata || {},
+      },
+    });
+
+    setMatrixState(result.persisted ? 'Route synced to Black Vault Matrix API.' : 'Route saved locally; API persistence pending.');
+    setIsSubmittingMatrix(false);
+  }, [form, fullUrl, ingestedLink]);
+
   return (
     <div className="space-y-8">
       <div>
         <h1 className="section-title">🔗 Affiliate Tracker</h1>
-        <p className="section-subtitle">SubID generator and performance analytics dashboard</p>
+        <p className="section-subtitle">SubID generator, redirect ingest, and Black Vault Matrix feed</p>
       </div>
 
       <div className="card">
@@ -191,9 +220,19 @@ export default function AffiliateTracker() {
           <div className="font-mono text-[10px] text-gray-500 break-all mb-3">
             {fullUrl}
           </div>
-          <button className="btn-primary text-xs" onClick={handleCopy}>
-            {copiedTarget === 'full' ? '✅ Copied!' : '📋 Copy Full URL'}
-          </button>
+          <div className="flex flex-wrap gap-2">
+            <button className="btn-primary text-xs" onClick={handleCopy}>
+              {copiedTarget === 'full' ? '✅ Copied!' : '📋 Copy Full URL'}
+            </button>
+            <button className="btn-emerald text-xs" onClick={handleSendToMatrix} disabled={isSubmittingMatrix}>
+              {isSubmittingMatrix ? '⏳ Sending...' : '🧬 Send to Black Vault Matrix'}
+            </button>
+          </div>
+          {matrixState && (
+            <div className="mt-3 rounded-lg border border-emerald-900/50 bg-emerald-950/20 px-3 py-2 text-xs text-emerald-200">
+              {matrixState}
+            </div>
+          )}
         </div>
       </div>
 

--- a/omega-hydra-app/src/components/tabs/BlackVaultConsole.jsx
+++ b/omega-hydra-app/src/components/tabs/BlackVaultConsole.jsx
@@ -12,6 +12,7 @@ import {
   fetchBlackVaultDashboard,
   saveBlackVaultOffer,
   syncBlackVaultWarpRuns,
+  createBlackVaultMetricSnapshot,
 } from '../../services/blackVaultService';
 
 const toneClasses = {
@@ -73,6 +74,7 @@ export default function BlackVaultConsole() {
   const [offers, setOffers] = useState(offerLadder.map(normalizeOffer));
   const [matrix, setMatrix] = useState(affiliateMatrix.map(normalizeMatrixRow));
   const [runs, setRuns] = useState(warpRuns.map(normalizeRun));
+  const [reviews, setReviews] = useState([]);
   const [dataSource, setDataSource] = useState('seed');
   const [isLoading, setIsLoading] = useState(true);
   const [editingOfferId, setEditingOfferId] = useState(null);
@@ -80,6 +82,8 @@ export default function BlackVaultConsole() {
   const [saveState, setSaveState] = useState(null);
   const [warpSyncState, setWarpSyncState] = useState(null);
   const [isSyncingWarp, setIsSyncingWarp] = useState(false);
+  const [snapshotState, setSnapshotState] = useState(null);
+  const [isSavingSnapshot, setIsSavingSnapshot] = useState(false);
 
   const hydrate = async () => {
     setIsLoading(true);
@@ -88,6 +92,7 @@ export default function BlackVaultConsole() {
     setOffers((dashboard.offers?.length ? dashboard.offers : offerLadder).map(normalizeOffer));
     setMatrix((dashboard.matrix?.length ? dashboard.matrix : affiliateMatrix).map(normalizeMatrixRow));
     setRuns((dashboard.runs?.length ? dashboard.runs : warpRuns).map(normalizeRun));
+    setReviews(dashboard.reviews || []);
     setDataSource(dashboard.source || 'unknown');
     setIsLoading(false);
   };
@@ -160,6 +165,31 @@ export default function BlackVaultConsole() {
     await hydrate();
   };
 
+  const saveMetricSnapshot = async () => {
+    setIsSavingSnapshot(true);
+    setSnapshotState(null);
+    const result = await createBlackVaultMetricSnapshot({
+      metrics,
+      offers,
+      matrix,
+      runs,
+      reviews,
+      metadata: {
+        source: dataSource,
+        liveRunningJobs: runningCount,
+      },
+    });
+
+    setSnapshotState(
+      result.error
+        ? `Snapshot unavailable: ${result.error}`
+        : result.persisted
+          ? 'Metric snapshot persisted to Black Vault storage.'
+          : 'Metric snapshot prepared, but persistence is pending.'
+    );
+    setIsSavingSnapshot(false);
+  };
+
   return (
     <div className="space-y-8">
       <section className="rounded-2xl border border-red-900/80 bg-gradient-to-br from-[#161018] via-[#120d14] to-[#0a0a0f] p-5 sm:p-6 shadow-[0_0_40px_rgba(127,29,29,0.16)]">
@@ -176,6 +206,7 @@ export default function BlackVaultConsole() {
               <span className="badge-violet">Source: {dataSource}</span>
               <span className="badge-blue">Live running jobs: {runningCount}</span>
               {saveState && <span className="badge-amber">{saveState}</span>}
+              {snapshotState && <span className="badge-green">{snapshotState}</span>}
             </div>
           </div>
           <div className="grid grid-cols-2 gap-2 text-xs sm:min-w-[280px]">
@@ -207,6 +238,19 @@ export default function BlackVaultConsole() {
             <div className="mt-1 text-xs opacity-90">{metric.delta}</div>
           </div>
         ))}
+      </section>
+
+      <section className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-[#1a1a2e] bg-[#101018] p-4">
+        <div>
+          <div className="text-sm font-bold text-white">Phase 2 persistence controls</div>
+          <div className="text-xs text-gray-500">Capture a metric snapshot or refresh the console against current API-backed state.</div>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <button className="btn-outline text-xs" onClick={hydrate}>Refresh Console</button>
+          <button className="btn-gold text-xs" onClick={saveMetricSnapshot} disabled={isSavingSnapshot}>
+            {isSavingSnapshot ? 'Saving Snapshot...' : 'Save Metric Snapshot'}
+          </button>
+        </div>
       </section>
 
       <section className="grid grid-cols-1 gap-6 xl:grid-cols-[1.1fr_1.4fr]">

--- a/omega-hydra-app/src/components/tabs/BlackVaultConsole.jsx
+++ b/omega-hydra-app/src/components/tabs/BlackVaultConsole.jsx
@@ -11,6 +11,7 @@ import {
 import {
   fetchBlackVaultDashboard,
   saveBlackVaultOffer,
+  syncBlackVaultWarpRuns,
 } from '../../services/blackVaultService';
 
 const toneClasses = {
@@ -77,25 +78,31 @@ export default function BlackVaultConsole() {
   const [editingOfferId, setEditingOfferId] = useState(null);
   const [offerDraft, setOfferDraft] = useState(null);
   const [saveState, setSaveState] = useState(null);
+  const [warpSyncState, setWarpSyncState] = useState(null);
+  const [isSyncingWarp, setIsSyncingWarp] = useState(false);
+
+  const hydrate = async () => {
+    setIsLoading(true);
+    const dashboard = await fetchBlackVaultDashboard();
+    setMetrics(dashboard.metrics?.length ? dashboard.metrics : vaultMetrics);
+    setOffers((dashboard.offers?.length ? dashboard.offers : offerLadder).map(normalizeOffer));
+    setMatrix((dashboard.matrix?.length ? dashboard.matrix : affiliateMatrix).map(normalizeMatrixRow));
+    setRuns((dashboard.runs?.length ? dashboard.runs : warpRuns).map(normalizeRun));
+    setDataSource(dashboard.source || 'unknown');
+    setIsLoading(false);
+  };
 
   useEffect(() => {
     let mounted = true;
 
-    const hydrate = async () => {
-      setIsLoading(true);
-      const dashboard = await fetchBlackVaultDashboard();
+    const safeHydrate = async () => {
       if (!mounted) return;
-      setMetrics(dashboard.metrics?.length ? dashboard.metrics : vaultMetrics);
-      setOffers((dashboard.offers?.length ? dashboard.offers : offerLadder).map(normalizeOffer));
-      setMatrix((dashboard.matrix?.length ? dashboard.matrix : affiliateMatrix).map(normalizeMatrixRow));
-      setRuns((dashboard.runs?.length ? dashboard.runs : warpRuns).map(normalizeRun));
-      setDataSource(dashboard.source || 'unknown');
-      setIsLoading(false);
+      await hydrate();
     };
 
-    hydrate();
+    safeHydrate();
 
-    const refreshFromMatrixEvent = () => hydrate();
+    const refreshFromMatrixEvent = () => safeHydrate();
     window.addEventListener('hydra:black-vault:matrix-updated', refreshFromMatrixEvent);
 
     return () => {
@@ -132,6 +139,25 @@ export default function BlackVaultConsole() {
     setSaveState(result.persisted ? 'Saved to API / storage' : 'Saved locally; API persistence pending');
     setEditingOfferId(null);
     setOfferDraft(null);
+    await hydrate();
+  };
+
+  const syncWarpRuns = async () => {
+    setIsSyncingWarp(true);
+    setWarpSyncState(null);
+    const sync = await syncBlackVaultWarpRuns();
+    if (sync.runs?.length) {
+      setRuns(sync.runs.map(normalizeRun));
+    }
+    setWarpSyncState(
+      sync.error
+        ? `Warp sync unavailable: ${sync.error}`
+        : sync.persisted
+          ? `Warp runs synced and persisted from ${sync.source}.`
+          : `Warp sync returned ${sync.runs.length} run(s) from ${sync.source}; persistence pending.`
+    );
+    setIsSyncingWarp(false);
+    await hydrate();
   };
 
   return (
@@ -291,13 +317,20 @@ export default function BlackVaultConsole() {
         </div>
 
         <div className="card border border-emerald-900/50">
-          <div className="flex items-center justify-between gap-3">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div>
               <h2 className="text-base font-bold text-white">⚡ Warp Limitless Run Center</h2>
-              <p className="text-xs text-gray-500">Hydrates from run API and accepts external run-event intake</p>
+              <p className="text-xs text-gray-500">Hydrates from run API, accepts run-event intake, and can sync from a configured Warp runs endpoint</p>
             </div>
-            <span className="badge-green">Live Queue</span>
+            <button className="btn-emerald text-xs" onClick={syncWarpRuns} disabled={isSyncingWarp}>
+              {isSyncingWarp ? 'Syncing...' : 'Sync Warp Runs'}
+            </button>
           </div>
+          {warpSyncState && (
+            <div className="mt-4 rounded-xl border border-emerald-900/50 bg-emerald-950/20 px-3 py-2 text-xs text-emerald-200">
+              {warpSyncState}
+            </div>
+          )}
           <div className="mt-4 space-y-3">
             {runs.map((run) => (
               <div key={run.id} className="rounded-xl border border-[#1a1a2e] bg-[#0a0a0f] p-4">

--- a/omega-hydra-app/src/components/tabs/BlackVaultConsole.jsx
+++ b/omega-hydra-app/src/components/tabs/BlackVaultConsole.jsx
@@ -1,0 +1,231 @@
+import {
+  vaultMetrics,
+  commandCouncil,
+  offerLadder,
+  affiliateMatrix,
+  warpRuns,
+  visualizerTracks,
+  pythonHeads,
+} from '../../data/blackVaultConsole';
+
+const toneClasses = {
+  violet: 'border-violet-700 text-violet-300',
+  emerald: 'border-emerald-700 text-emerald-300',
+  crimson: 'border-red-700 text-red-300',
+  gold: 'border-amber-700 text-amber-300',
+};
+
+const decisionBadges = {
+  Scale: 'badge-green',
+  Refine: 'badge-amber',
+  Monitor: 'badge-violet',
+};
+
+const statusBadges = {
+  Running: 'badge-green',
+  Queued: 'badge-amber',
+  Review: 'badge-violet',
+  Completed: 'badge-blue',
+};
+
+export default function BlackVaultConsole() {
+  return (
+    <div className="space-y-8">
+      <section className="rounded-2xl border border-red-900/80 bg-gradient-to-br from-[#161018] via-[#120d14] to-[#0a0a0f] p-5 sm:p-6 shadow-[0_0_40px_rgba(127,29,29,0.16)]">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div>
+            <div className="text-xs uppercase tracking-[0.3em] text-amber-400">Private age-gated command branch</div>
+            <h1 className="mt-2 text-2xl sm:text-3xl font-black text-white">🗝 Velvet Grin Black Vault Console</h1>
+            <p className="mt-2 max-w-4xl text-sm text-gray-300 leading-relaxed">
+              Warp.dev Limitless × Omega Hydra CEO operating surface for gated affiliate funnels, mature fictional media planning,
+              Vault IP governance, revenue intelligence, and Den Mother review discipline.
+            </p>
+          </div>
+          <div className="grid grid-cols-2 gap-2 text-xs sm:min-w-[280px]">
+            <div className="rounded-xl border border-emerald-800/70 bg-emerald-950/20 p-3">
+              <div className="text-gray-500 uppercase tracking-widest">Boundary</div>
+              <div className="mt-1 font-bold text-emerald-300">Public / Private Split</div>
+            </div>
+            <div className="rounded-xl border border-amber-800/70 bg-amber-950/20 p-3">
+              <div className="text-gray-500 uppercase tracking-widest">CEO Logic</div>
+              <div className="mt-1 font-bold text-amber-300">Evidence Gate</div>
+            </div>
+            <div className="rounded-xl border border-red-800/70 bg-red-950/20 p-3">
+              <div className="text-gray-500 uppercase tracking-widest">Access</div>
+              <div className="mt-1 font-bold text-red-300">Age-Gated Only</div>
+            </div>
+            <div className="rounded-xl border border-violet-800/70 bg-violet-950/20 p-3">
+              <div className="text-gray-500 uppercase tracking-widest">Mode</div>
+              <div className="mt-1 font-bold text-violet-300">Affiliate Matrix</div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="grid grid-cols-2 gap-4 sm:grid-cols-4 xl:grid-cols-8">
+        {vaultMetrics.map((metric) => (
+          <div key={metric.label} className={`metric-card border ${toneClasses[metric.tone] || toneClasses.violet}`}>
+            <div className="text-[10px] uppercase tracking-widest text-gray-500">{metric.label}</div>
+            <div className="mt-2 text-xl font-black text-white">{metric.value}</div>
+            <div className="mt-1 text-xs opacity-90">{metric.delta}</div>
+          </div>
+        ))}
+      </section>
+
+      <section className="grid grid-cols-1 gap-6 xl:grid-cols-[1.1fr_1.4fr]">
+        <div className="card border border-red-900/50">
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <h2 className="text-base font-bold text-white">👑 Command Council</h2>
+              <p className="text-xs text-gray-500">Jezebel Velvet, Black Grin, Den Mother, CEO Logic</p>
+            </div>
+            <span className="badge-red">Private Branch</span>
+          </div>
+          <div className="mt-4 space-y-3">
+            {commandCouncil.map((leader) => (
+              <div key={leader.name} className="rounded-xl border border-[#252031] bg-[#0a0a0f] p-4">
+                <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                  <div>
+                    <div className="font-semibold text-white">{leader.name}</div>
+                    <div className="text-xs uppercase tracking-widest text-violet-400">{leader.role}</div>
+                  </div>
+                  <span className="badge-green">{leader.status}</span>
+                </div>
+                <p className="mt-3 text-xs leading-relaxed text-gray-400">{leader.focus}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="card border border-amber-900/50">
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <h2 className="text-base font-bold text-white">🪜 Offer Ladder / Black Vault Revenue Rail</h2>
+              <p className="text-xs text-gray-500">Traffic signal → gated route → product pack → premium console</p>
+            </div>
+            <span className="badge-amber">Commercial Bridge</span>
+          </div>
+          <div className="mt-4 grid grid-cols-1 gap-3 lg:grid-cols-5">
+            {offerLadder.map((offer) => (
+              <div key={offer.title} className="rounded-xl border border-amber-900/40 bg-[#0a0a0f] p-4">
+                <div className="text-[10px] uppercase tracking-widest text-amber-400">{offer.tier}</div>
+                <div className="mt-2 text-sm font-bold text-white">{offer.title}</div>
+                <div className="mt-2 text-lg font-black text-emerald-300">{offer.price}</div>
+                <p className="mt-3 text-xs leading-relaxed text-gray-400">{offer.purpose}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="grid grid-cols-1 gap-6 xl:grid-cols-[1.25fr_0.95fr]">
+        <div className="card border border-violet-900/50">
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <h2 className="text-base font-bold text-white">🧬 Velvet Affiliate Matrix</h2>
+              <p className="text-xs text-gray-500">Offer lane performance, CTA posture, and CEO decisions</p>
+            </div>
+            <span className="badge-violet">EPC / CTR / Decision</span>
+          </div>
+          <div className="table-container mt-4">
+            <table>
+              <thead>
+                <tr>
+                  <th>Lane</th>
+                  <th>Source</th>
+                  <th>CTA</th>
+                  <th>CTR</th>
+                  <th>EPC</th>
+                  <th>Decision</th>
+                </tr>
+              </thead>
+              <tbody>
+                {affiliateMatrix.map((row) => (
+                  <tr key={row.lane}>
+                    <td className="font-medium text-white">{row.lane}</td>
+                    <td className="text-gray-400">{row.source}</td>
+                    <td className="text-gray-400">{row.cta}</td>
+                    <td className="font-semibold text-amber-300">{row.ctr}</td>
+                    <td className="font-semibold text-emerald-300">{row.epc}</td>
+                    <td><span className={decisionBadges[row.decision] || 'badge-violet'}>{row.decision}</span></td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <div className="card border border-emerald-900/50">
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <h2 className="text-base font-bold text-white">⚡ Warp Limitless Run Center</h2>
+              <p className="text-xs text-gray-500">Automation queue for gated commercial workflows</p>
+            </div>
+            <span className="badge-green">Live Queue</span>
+          </div>
+          <div className="mt-4 space-y-3">
+            {warpRuns.map((run) => (
+              <div key={run.run} className="rounded-xl border border-[#1a1a2e] bg-[#0a0a0f] p-4">
+                <div className="flex items-center justify-between gap-3">
+                  <div>
+                    <div className="font-mono text-xs text-violet-300">{run.run}</div>
+                    <div className="mt-1 text-sm font-semibold text-white">{run.task}</div>
+                  </div>
+                  <span className={statusBadges[run.status] || 'badge-violet'}>{run.status}</span>
+                </div>
+                <div className="progress-bar mt-3">
+                  <div className="progress-fill bg-emerald-600" style={{ width: `${run.progress}%` }} />
+                </div>
+                <div className="mt-2 text-[10px] uppercase tracking-widest text-gray-500">Progress {run.progress}%</div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="grid grid-cols-1 gap-6 xl:grid-cols-[1fr_1fr]">
+        <div className="card border border-blue-900/50">
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <h2 className="text-base font-bold text-white">🖼 Mature Media Visualizer Stack</h2>
+              <p className="text-xs text-gray-500">Private fictional IP planning, cataloging, and boundary control</p>
+            </div>
+            <span className="badge-blue">Visualizer</span>
+          </div>
+          <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2">
+            {visualizerTracks.map((track) => (
+              <div key={track.title} className="rounded-xl border border-blue-900/40 bg-[#0a0a0f] p-4">
+                <div className="text-sm font-bold text-white">{track.title}</div>
+                <p className="mt-2 text-xs leading-relaxed text-gray-400">{track.focus}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="card border border-red-900/50">
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <h2 className="text-base font-bold text-white">🐍 Black Vault Python Heads</h2>
+              <p className="text-xs text-gray-500">Specialized automation heads assigned to the gated branch</p>
+            </div>
+            <span className="badge-red">Swarm</span>
+          </div>
+          <div className="mt-4 flex flex-wrap gap-2">
+            {pythonHeads.map((head) => (
+              <span key={head} className="rounded-full border border-red-900/70 bg-red-950/20 px-3 py-2 text-xs font-medium text-red-200">
+                {head}
+              </span>
+            ))}
+          </div>
+          <div className="mt-5 rounded-xl border border-amber-900/40 bg-amber-950/10 p-4">
+            <div className="text-xs font-bold uppercase tracking-widest text-amber-400">CEO Logic Boundary</div>
+            <p className="mt-2 text-sm leading-relaxed text-gray-300">
+              Public-safe Hydra outputs remain separated from this branch. Mature assets route through age-gated disclosures,
+              Den Mother review, and offer-level evidence checks before release.
+            </p>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/omega-hydra-app/src/components/tabs/BlackVaultConsole.jsx
+++ b/omega-hydra-app/src/components/tabs/BlackVaultConsole.jsx
@@ -1,3 +1,4 @@
+import { useEffect, useMemo, useState } from 'react';
 import {
   vaultMetrics,
   commandCouncil,
@@ -7,6 +8,10 @@ import {
   visualizerTracks,
   pythonHeads,
 } from '../../data/blackVaultConsole';
+import {
+  fetchBlackVaultDashboard,
+  saveBlackVaultOffer,
+} from '../../services/blackVaultService';
 
 const toneClasses = {
   violet: 'border-violet-700 text-violet-300',
@@ -23,12 +28,112 @@ const decisionBadges = {
 
 const statusBadges = {
   Running: 'badge-green',
+  running: 'badge-green',
   Queued: 'badge-amber',
+  queued: 'badge-amber',
   Review: 'badge-violet',
+  review: 'badge-violet',
   Completed: 'badge-blue',
+  completed: 'badge-blue',
 };
 
+const normalizeOffer = (offer, index) => ({
+  id: offer.id || `offer-${index + 1}`,
+  tier: offer.tier || offer.offer_tier || 'Tier',
+  title: offer.title || 'Untitled Offer',
+  price: offer.price || offer.price_label || 'TBD',
+  purpose: offer.purpose || offer.description || '',
+  status: offer.status || 'active',
+  accessTier: offer.accessTier || offer.access_tier || 'age-gated',
+  sortOrder: offer.sortOrder ?? offer.sort_order ?? index + 1,
+});
+
+const normalizeMatrixRow = (row, index) => ({
+  id: row.id || `matrix-${index + 1}`,
+  lane: row.lane || 'Tracker Route',
+  source: row.source || 'unknown',
+  cta: row.cta || 'Tracked CTA',
+  ctr: row.ctr || row.ctr_label || '—',
+  epc: row.epc || row.epc_label || '—',
+  decision: row.decision || 'Monitor',
+  trackingUrl: row.trackingUrl || row.tracking_url || '',
+});
+
+const normalizeRun = (run, index) => ({
+  id: run.id || `run-${index + 1}`,
+  run: run.run || run.run_id || `Warp-VA-${index + 1}`,
+  task: run.task || 'Unlabeled run',
+  status: run.status || 'Queued',
+  progress: Number(run.progress || 0),
+});
+
 export default function BlackVaultConsole() {
+  const [metrics, setMetrics] = useState(vaultMetrics);
+  const [offers, setOffers] = useState(offerLadder.map(normalizeOffer));
+  const [matrix, setMatrix] = useState(affiliateMatrix.map(normalizeMatrixRow));
+  const [runs, setRuns] = useState(warpRuns.map(normalizeRun));
+  const [dataSource, setDataSource] = useState('seed');
+  const [isLoading, setIsLoading] = useState(true);
+  const [editingOfferId, setEditingOfferId] = useState(null);
+  const [offerDraft, setOfferDraft] = useState(null);
+  const [saveState, setSaveState] = useState(null);
+
+  useEffect(() => {
+    let mounted = true;
+
+    const hydrate = async () => {
+      setIsLoading(true);
+      const dashboard = await fetchBlackVaultDashboard();
+      if (!mounted) return;
+      setMetrics(dashboard.metrics?.length ? dashboard.metrics : vaultMetrics);
+      setOffers((dashboard.offers?.length ? dashboard.offers : offerLadder).map(normalizeOffer));
+      setMatrix((dashboard.matrix?.length ? dashboard.matrix : affiliateMatrix).map(normalizeMatrixRow));
+      setRuns((dashboard.runs?.length ? dashboard.runs : warpRuns).map(normalizeRun));
+      setDataSource(dashboard.source || 'unknown');
+      setIsLoading(false);
+    };
+
+    hydrate();
+
+    const refreshFromMatrixEvent = () => hydrate();
+    window.addEventListener('hydra:black-vault:matrix-updated', refreshFromMatrixEvent);
+
+    return () => {
+      mounted = false;
+      window.removeEventListener('hydra:black-vault:matrix-updated', refreshFromMatrixEvent);
+    };
+  }, []);
+
+  const runningCount = useMemo(
+    () => runs.filter((run) => String(run.status).toLowerCase() === 'running').length,
+    [runs]
+  );
+
+  const beginOfferEdit = (offer) => {
+    setEditingOfferId(offer.id);
+    setOfferDraft({ ...offer });
+    setSaveState(null);
+  };
+
+  const updateDraft = (key, value) => {
+    setOfferDraft((draft) => ({ ...draft, [key]: value }));
+  };
+
+  const cancelOfferEdit = () => {
+    setEditingOfferId(null);
+    setOfferDraft(null);
+    setSaveState(null);
+  };
+
+  const saveOffer = async () => {
+    if (!offerDraft) return;
+    const result = await saveBlackVaultOffer(offerDraft);
+    setOffers((current) => current.map((offer) => offer.id === offerDraft.id ? { ...offer, ...result.offer } : offer));
+    setSaveState(result.persisted ? 'Saved to API / storage' : 'Saved locally; API persistence pending');
+    setEditingOfferId(null);
+    setOfferDraft(null);
+  };
+
   return (
     <div className="space-y-8">
       <section className="rounded-2xl border border-red-900/80 bg-gradient-to-br from-[#161018] via-[#120d14] to-[#0a0a0f] p-5 sm:p-6 shadow-[0_0_40px_rgba(127,29,29,0.16)]">
@@ -40,6 +145,12 @@ export default function BlackVaultConsole() {
               Warp.dev Limitless × Omega Hydra CEO operating surface for gated affiliate funnels, mature fictional media planning,
               Vault IP governance, revenue intelligence, and Den Mother review discipline.
             </p>
+            <div className="mt-3 flex flex-wrap gap-2 text-xs">
+              <span className={isLoading ? 'badge-amber' : 'badge-green'}>{isLoading ? 'Hydrating console' : 'Console hydrated'}</span>
+              <span className="badge-violet">Source: {dataSource}</span>
+              <span className="badge-blue">Live running jobs: {runningCount}</span>
+              {saveState && <span className="badge-amber">{saveState}</span>}
+            </div>
           </div>
           <div className="grid grid-cols-2 gap-2 text-xs sm:min-w-[280px]">
             <div className="rounded-xl border border-emerald-800/70 bg-emerald-950/20 p-3">
@@ -63,7 +174,7 @@ export default function BlackVaultConsole() {
       </section>
 
       <section className="grid grid-cols-2 gap-4 sm:grid-cols-4 xl:grid-cols-8">
-        {vaultMetrics.map((metric) => (
+        {metrics.map((metric) => (
           <div key={metric.label} className={`metric-card border ${toneClasses[metric.tone] || toneClasses.violet}`}>
             <div className="text-[10px] uppercase tracking-widest text-gray-500">{metric.label}</div>
             <div className="mt-2 text-xl font-black text-white">{metric.value}</div>
@@ -98,22 +209,46 @@ export default function BlackVaultConsole() {
         </div>
 
         <div className="card border border-amber-900/50">
-          <div className="flex items-center justify-between gap-3">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div>
               <h2 className="text-base font-bold text-white">🪜 Offer Ladder / Black Vault Revenue Rail</h2>
-              <p className="text-xs text-gray-500">Traffic signal → gated route → product pack → premium console</p>
+              <p className="text-xs text-gray-500">Editable commercial objects with API/local fallback persistence</p>
             </div>
             <span className="badge-amber">Commercial Bridge</span>
           </div>
           <div className="mt-4 grid grid-cols-1 gap-3 lg:grid-cols-5">
-            {offerLadder.map((offer) => (
-              <div key={offer.title} className="rounded-xl border border-amber-900/40 bg-[#0a0a0f] p-4">
-                <div className="text-[10px] uppercase tracking-widest text-amber-400">{offer.tier}</div>
-                <div className="mt-2 text-sm font-bold text-white">{offer.title}</div>
-                <div className="mt-2 text-lg font-black text-emerald-300">{offer.price}</div>
-                <p className="mt-3 text-xs leading-relaxed text-gray-400">{offer.purpose}</p>
-              </div>
-            ))}
+            {offers.map((offer) => {
+              const editing = editingOfferId === offer.id;
+              const draft = editing ? offerDraft : offer;
+              return (
+                <div key={offer.id} className="rounded-xl border border-amber-900/40 bg-[#0a0a0f] p-4">
+                  <div className="text-[10px] uppercase tracking-widest text-amber-400">{draft.tier}</div>
+                  {editing ? (
+                    <div className="mt-3 space-y-2">
+                      <input className="input-field text-xs" value={draft.title} onChange={(event) => updateDraft('title', event.target.value)} />
+                      <input className="input-field text-xs" value={draft.price} onChange={(event) => updateDraft('price', event.target.value)} />
+                      <textarea className="textarea-field text-xs" rows={4} value={draft.purpose} onChange={(event) => updateDraft('purpose', event.target.value)} />
+                    </div>
+                  ) : (
+                    <>
+                      <div className="mt-2 text-sm font-bold text-white">{draft.title}</div>
+                      <div className="mt-2 text-lg font-black text-emerald-300">{draft.price}</div>
+                      <p className="mt-3 text-xs leading-relaxed text-gray-400">{draft.purpose}</p>
+                    </>
+                  )}
+                  <div className="mt-4 flex flex-wrap gap-2">
+                    {editing ? (
+                      <>
+                        <button className="btn-emerald text-xs py-1 px-2" onClick={saveOffer}>Save</button>
+                        <button className="btn-outline text-xs py-1 px-2" onClick={cancelOfferEdit}>Cancel</button>
+                      </>
+                    ) : (
+                      <button className="btn-outline text-xs py-1 px-2" onClick={() => beginOfferEdit(offer)}>Edit</button>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
           </div>
         </div>
       </section>
@@ -123,7 +258,7 @@ export default function BlackVaultConsole() {
           <div className="flex items-center justify-between gap-3">
             <div>
               <h2 className="text-base font-bold text-white">🧬 Velvet Affiliate Matrix</h2>
-              <p className="text-xs text-gray-500">Offer lane performance, CTA posture, and CEO decisions</p>
+              <p className="text-xs text-gray-500">Tracker-linked rows appear here after route submission</p>
             </div>
             <span className="badge-violet">EPC / CTR / Decision</span>
           </div>
@@ -140,8 +275,8 @@ export default function BlackVaultConsole() {
                 </tr>
               </thead>
               <tbody>
-                {affiliateMatrix.map((row) => (
-                  <tr key={row.lane}>
+                {matrix.map((row) => (
+                  <tr key={row.id}>
                     <td className="font-medium text-white">{row.lane}</td>
                     <td className="text-gray-400">{row.source}</td>
                     <td className="text-gray-400">{row.cta}</td>
@@ -159,13 +294,13 @@ export default function BlackVaultConsole() {
           <div className="flex items-center justify-between gap-3">
             <div>
               <h2 className="text-base font-bold text-white">⚡ Warp Limitless Run Center</h2>
-              <p className="text-xs text-gray-500">Automation queue for gated commercial workflows</p>
+              <p className="text-xs text-gray-500">Hydrates from run API and accepts external run-event intake</p>
             </div>
             <span className="badge-green">Live Queue</span>
           </div>
           <div className="mt-4 space-y-3">
-            {warpRuns.map((run) => (
-              <div key={run.run} className="rounded-xl border border-[#1a1a2e] bg-[#0a0a0f] p-4">
+            {runs.map((run) => (
+              <div key={run.id} className="rounded-xl border border-[#1a1a2e] bg-[#0a0a0f] p-4">
                 <div className="flex items-center justify-between gap-3">
                   <div>
                     <div className="font-mono text-xs text-violet-300">{run.run}</div>

--- a/omega-hydra-app/src/components/tabs/ComplianceCenter.jsx
+++ b/omega-hydra-app/src/components/tabs/ComplianceCenter.jsx
@@ -1,3 +1,9 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  fetchBlackVaultReviews,
+  updateBlackVaultReviewStatus,
+} from '../../services/blackVaultService';
+
 const checklist = [
   { icon: '✅', label: 'Public-safe content', status: 'Pass', badge: 'badge-green' },
   { icon: '✅', label: 'Age gate on all mature content', status: 'Pass', badge: 'badge-green' },
@@ -9,38 +15,106 @@ const checklist = [
   { icon: '✅', label: 'Approved for distribution', status: 'Approved', badge: 'badge-green' },
 ];
 
-const reviewQueue = [
-  { title: "Velrya's Vow — Public Teaser", type: "Character Spotlight", status: "Approved", risk: "Low" },
-  { title: "The Ninth Veil — Full Scene", type: "18+ Content", status: "Needs Review", risk: "Medium" },
-  { title: "Serpent Sun Banquet Scene", type: "18+ Content", status: "Approved", risk: "Low" },
-  { title: "Hydra Labyrinth Manifesto", type: "Faction Identity", status: "Approved", risk: "Low" },
-  { title: "Den Mother's Protocol — Gated", type: "18+ Content", status: "Blocked", risk: "High" },
+const seededReviewQueue = [
+  { id: 'seed-review-1', title: "Velrya's Vow — Public Teaser", type: 'Character Spotlight', status: 'Approved', risk: 'Low', owner: 'Den Mother' },
+  { id: 'seed-review-2', title: 'The Ninth Veil — Full Scene', type: '18+ Content', status: 'Needs Review', risk: 'Medium', owner: 'Den Mother' },
+  { id: 'seed-review-3', title: 'Serpent Sun Banquet Scene', type: '18+ Content', status: 'Approved', risk: 'Low', owner: 'Den Mother' },
+  { id: 'seed-review-4', title: 'Hydra Labyrinth Manifesto', type: 'Faction Identity', status: 'Approved', risk: 'Low', owner: 'Den Mother' },
+  { id: 'seed-review-5', title: "Den Mother's Protocol — Gated", type: '18+ Content', status: 'Blocked', risk: 'High', owner: 'Den Mother' },
 ];
 
 const statusColor = {
-  Approved: "badge-green",
-  "Needs Review": "badge-amber",
-  Blocked: "badge-red",
+  Approved: 'badge-green',
+  approved: 'badge-green',
+  'Needs Review': 'badge-amber',
+  'needs-review': 'badge-amber',
+  Pending: 'badge-amber',
+  pending: 'badge-amber',
+  Blocked: 'badge-red',
+  blocked: 'badge-red',
 };
 
 const riskColor = {
-  Low: "badge-green",
-  Medium: "badge-amber",
-  High: "badge-red",
+  Low: 'badge-green',
+  low: 'badge-green',
+  Medium: 'badge-amber',
+  medium: 'badge-amber',
+  High: 'badge-red',
+  high: 'badge-red',
 };
 
+const normalizeReview = (item, index) => ({
+  id: item.id || `review-${index + 1}`,
+  title: item.title || 'Untitled review item',
+  type: item.type || 'Vault Review',
+  status: item.status || 'Needs Review',
+  risk: item.risk || 'Medium',
+  owner: item.owner || 'Den Mother',
+  notes: item.notes || '',
+});
+
 export default function ComplianceCenter() {
+  const [reviewQueue, setReviewQueue] = useState(seededReviewQueue);
+  const [reviewSource, setReviewSource] = useState('seed');
+  const [loadingReviews, setLoadingReviews] = useState(true);
+  const [actionState, setActionState] = useState(null);
+
+  useEffect(() => {
+    let mounted = true;
+    const hydrateReviews = async () => {
+      setLoadingReviews(true);
+      const reviews = await fetchBlackVaultReviews();
+      if (!mounted) return;
+      setReviewQueue((reviews?.length ? reviews : seededReviewQueue).map(normalizeReview));
+      setReviewSource(reviews?.length ? 'api / storage' : 'seed');
+      setLoadingReviews(false);
+    };
+
+    hydrateReviews();
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const counts = useMemo(() => ({
+    approved: reviewQueue.filter((item) => String(item.status).toLowerCase() === 'approved').length,
+    pending: reviewQueue.filter((item) => ['needs review', 'needs-review', 'pending'].includes(String(item.status).toLowerCase())).length,
+    blocked: reviewQueue.filter((item) => String(item.status).toLowerCase() === 'blocked').length,
+  }), [reviewQueue]);
+
+  const setReviewStatus = async (item, nextStatus) => {
+    const optimistic = reviewQueue.map((review) => review.id === item.id ? { ...review, status: nextStatus } : review);
+    setReviewQueue(optimistic);
+    const result = await updateBlackVaultReviewStatus(item.id, nextStatus);
+    setActionState(result.persisted ? `${item.title}: ${nextStatus} persisted.` : `${item.title}: ${nextStatus} saved locally; API persistence pending.`);
+  };
+
   return (
     <div className="space-y-8">
       <div>
         <h1 className="section-title">✅ Compliance Center</h1>
-        <p className="section-subtitle">Platform risk monitoring and content compliance dashboard</p>
+        <p className="section-subtitle">Platform risk monitoring, Den Mother review queue, and release discipline</p>
       </div>
 
       <div className="bg-amber-950/30 border border-amber-700 rounded-xl p-5">
         <div className="text-xs text-amber-500 uppercase tracking-widest font-bold mb-2">Required Disclosure</div>
         <div className="text-amber-300 font-semibold">
           AI-generated fantasy characters. Affiliate links may generate commissions. 18+ destinations are age-gated.
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        <div className="metric-card border border-emerald-700">
+          <div className="text-xs uppercase tracking-widest text-gray-500">Approved</div>
+          <div className="mt-2 text-2xl font-black text-emerald-300">{counts.approved}</div>
+        </div>
+        <div className="metric-card border border-amber-700">
+          <div className="text-xs uppercase tracking-widest text-gray-500">Needs Review</div>
+          <div className="mt-2 text-2xl font-black text-amber-300">{counts.pending}</div>
+        </div>
+        <div className="metric-card border border-red-700">
+          <div className="text-xs uppercase tracking-widest text-gray-500">Blocked</div>
+          <div className="mt-2 text-2xl font-black text-red-300">{counts.blocked}</div>
         </div>
       </div>
 
@@ -60,7 +134,13 @@ export default function ComplianceCenter() {
       </div>
 
       <div className="card">
-        <h2 className="text-base font-bold text-white mb-4">📋 Content Review Queue</h2>
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between mb-4">
+          <div>
+            <h2 className="text-base font-bold text-white">📋 Den Mother Review Queue</h2>
+            <p className="text-xs text-gray-500">Source: {loadingReviews ? 'loading' : reviewSource}</p>
+          </div>
+          {actionState && <span className="badge-amber">{actionState}</span>}
+        </div>
         <div className="table-container">
           <table>
             <thead>
@@ -69,20 +149,23 @@ export default function ComplianceCenter() {
                 <th>Type</th>
                 <th>Status</th>
                 <th>Risk</th>
+                <th>Owner</th>
                 <th>Actions</th>
               </tr>
             </thead>
             <tbody>
               {reviewQueue.map((item) => (
-                <tr key={item.title}>
+                <tr key={item.id}>
                   <td className="font-medium text-gray-200">{item.title}</td>
                   <td className="text-gray-400 text-xs">{item.type}</td>
-                  <td><span className={statusColor[item.status]}>{item.status}</span></td>
-                  <td><span className={riskColor[item.risk]}>{item.risk}</span></td>
+                  <td><span className={statusColor[item.status] || 'badge-violet'}>{item.status}</span></td>
+                  <td><span className={riskColor[item.risk] || 'badge-violet'}>{item.risk}</span></td>
+                  <td className="text-xs text-violet-300">{item.owner}</td>
                   <td>
-                    <div className="flex gap-2">
-                      <button className="btn-emerald text-xs py-1 px-2">Approve</button>
-                      <button className="btn-crimson text-xs py-1 px-2">Block</button>
+                    <div className="flex flex-wrap gap-2">
+                      <button className="btn-emerald text-xs py-1 px-2" onClick={() => setReviewStatus(item, 'Approved')}>Approve</button>
+                      <button className="btn-outline text-xs py-1 px-2" onClick={() => setReviewStatus(item, 'Needs Review')}>Review</button>
+                      <button className="btn-crimson text-xs py-1 px-2" onClick={() => setReviewStatus(item, 'Blocked')}>Block</button>
                     </div>
                   </td>
                 </tr>

--- a/omega-hydra-app/src/data/blackVaultConsole.js
+++ b/omega-hydra-app/src/data/blackVaultConsole.js
@@ -1,0 +1,143 @@
+export const vaultMetrics = [
+  { label: 'Active Offers', value: '18', tone: 'violet', delta: '+3 this week' },
+  { label: 'Live Warp Runs', value: '11', tone: 'emerald', delta: '7 running' },
+  { label: 'Age-Gated Pages', value: '42', tone: 'crimson', delta: '100% routed' },
+  { label: 'Affiliate EPC', value: '$2.74', tone: 'gold', delta: '+12.6%' },
+  { label: 'Vault CTR', value: '6.9%', tone: 'emerald', delta: '+0.8 pts' },
+  { label: 'Prompt Packs', value: '9', tone: 'violet', delta: '3 in review' },
+  { label: 'SEO Clusters', value: '27', tone: 'gold', delta: '4 refreshed' },
+  { label: 'Review Alerts', value: '2', tone: 'crimson', delta: 'Needs action' },
+];
+
+export const commandCouncil = [
+  {
+    name: 'Jezebel Velvet',
+    role: 'Conversion Studio',
+    focus: 'Offer presentation, premium packaging, landing-page magnetism, and mature editorial art direction.',
+    status: 'Online',
+  },
+  {
+    name: 'Black Grin',
+    role: 'Revenue Intelligence',
+    focus: 'EPC, CTR, funnel performance, offer ranking, and scale / refine recommendations.',
+    status: 'Online',
+  },
+  {
+    name: 'Den Mother',
+    role: 'Vault Governance',
+    focus: 'Age-gate integrity, public/private separation, disclosure hygiene, and review discipline.',
+    status: 'Guarding',
+  },
+  {
+    name: 'CEO Logic',
+    role: 'Final Decision Layer',
+    focus: 'Approve, hold, refine, or archive system lanes based on evidence and policy boundaries.',
+    status: 'Adjudicating',
+  },
+];
+
+export const offerLadder = [
+  {
+    tier: 'Entry',
+    title: 'Velvet Teaser Kit',
+    price: 'Free',
+    purpose: 'Audience warming, list capture, and first-touch curiosity.',
+  },
+  {
+    tier: 'Starter',
+    title: 'Black Vault Prompt Starter',
+    price: '$9',
+    purpose: 'Compact prompt pack for persona visuals, article angles, and CTA hooks.',
+  },
+  {
+    tier: 'Core',
+    title: 'Velvet Founder Pack',
+    price: '$27',
+    purpose: 'Persona bundle, funnel copy, landing-page blocks, and vault asset templates.',
+  },
+  {
+    tier: 'Growth',
+    title: 'Affiliate Matrix Kit',
+    price: '$97',
+    purpose: 'SEO cluster map, review templates, tracking logic, and refresh cadence.',
+  },
+  {
+    tier: 'Premium',
+    title: 'Black Vault Console System',
+    price: '$197',
+    purpose: 'Command deck templates, dashboards, governance rails, and workflow packs.',
+  },
+];
+
+export const affiliateMatrix = [
+  {
+    lane: 'Review Hub',
+    source: 'SEO',
+    cta: 'Comparison CTA',
+    ctr: '5.8%',
+    epc: '$2.14',
+    decision: 'Scale',
+  },
+  {
+    lane: 'Alternatives Cluster',
+    source: 'Blog',
+    cta: 'Ranked CTA',
+    ctr: '4.1%',
+    epc: '$1.76',
+    decision: 'Refine',
+  },
+  {
+    lane: 'Vault Email',
+    source: 'Email',
+    cta: 'Prompt Pack Upsell',
+    ctr: '7.4%',
+    epc: '$3.33',
+    decision: 'Scale',
+  },
+  {
+    lane: 'Profile Link Hub',
+    source: 'Social',
+    cta: 'Age-Gated Route',
+    ctr: '3.2%',
+    epc: '$1.09',
+    decision: 'Monitor',
+  },
+];
+
+export const warpRuns = [
+  { run: 'Warp-VA-024', task: 'Offer matrix refresh', status: 'Running', progress: 72 },
+  { run: 'Warp-VA-025', task: 'Vault metadata tagging', status: 'Running', progress: 54 },
+  { run: 'Warp-VA-026', task: 'Quarterly SEO refresh', status: 'Queued', progress: 0 },
+  { run: 'Warp-VA-027', task: 'Affiliate SubID rollup', status: 'Review', progress: 100 },
+  { run: 'Warp-VA-028', task: 'Landing-page variant pack', status: 'Completed', progress: 100 },
+];
+
+export const visualizerTracks = [
+  {
+    title: 'Persona Moodboards',
+    focus: 'Curated visual boards, character continuity, and premium vault positioning.',
+  },
+  {
+    title: 'Scene Pack Catalogs',
+    focus: 'Reusable scene concepts, editorial palettes, and asset grouping for gated releases.',
+  },
+  {
+    title: 'Prompt Vault Tags',
+    focus: 'Tone, audience, offer, traffic source, and review-state metadata.',
+  },
+  {
+    title: 'Public / Private Split',
+    focus: 'Clear boundary rules so public-safe materials never blend into gated releases.',
+  },
+];
+
+export const pythonHeads = [
+  'Vault Governance Python',
+  'Affiliate Matrix Python',
+  'Visualizer Stack Python',
+  'Offer Ladder Python',
+  'SubID Attribution Python',
+  'SEO Refresh Python',
+  'Disclosure Audit Python',
+  'CEO Decision Python',
+];

--- a/omega-hydra-app/src/services/blackVaultService.js
+++ b/omega-hydra-app/src/services/blackVaultService.js
@@ -1,0 +1,182 @@
+import {
+  vaultMetrics,
+  offerLadder,
+  affiliateMatrix,
+  warpRuns,
+} from '../data/blackVaultConsole';
+
+const STORAGE_KEYS = {
+  offers: 'hydra:black-vault:offers',
+  matrix: 'hydra:black-vault:matrix',
+  reviews: 'hydra:black-vault:reviews',
+};
+
+const safeJson = async (response) => {
+  try {
+    return await response.json();
+  } catch {
+    return null;
+  }
+};
+
+const readStorage = (key, fallback) => {
+  if (typeof window === 'undefined') return fallback;
+  try {
+    const raw = window.localStorage.getItem(key);
+    return raw ? JSON.parse(raw) : fallback;
+  } catch {
+    return fallback;
+  }
+};
+
+const writeStorage = (key, value) => {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(key, JSON.stringify(value));
+  } catch {
+    // Storage can fail in private browsing or restricted environments.
+  }
+};
+
+const normalizeOffers = (remoteOffers) => {
+  const cachedOffers = readStorage(STORAGE_KEYS.offers, []);
+  const baseline = Array.isArray(remoteOffers) && remoteOffers.length ? remoteOffers : offerLadder;
+  const cachedById = new Map(cachedOffers.map((offer) => [offer.id, offer]));
+  return baseline.map((offer, index) => {
+    const id = offer.id || `offer-${index + 1}`;
+    return {
+      ...offer,
+      id,
+      ...cachedById.get(id),
+    };
+  });
+};
+
+const normalizeMatrix = (remoteRows) => {
+  const cachedRows = readStorage(STORAGE_KEYS.matrix, []);
+  const baseline = Array.isArray(remoteRows) && remoteRows.length ? remoteRows : affiliateMatrix;
+  const merged = [...cachedRows, ...baseline];
+  const seen = new Set();
+
+  return merged.filter((row) => {
+    const key = row.id || `${row.lane}:${row.source}:${row.cta}:${row.trackingUrl || row.tracking_url || ''}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+};
+
+const normalizeRuns = (remoteRuns) => (
+  Array.isArray(remoteRuns) && remoteRuns.length ? remoteRuns : warpRuns
+);
+
+export async function fetchBlackVaultDashboard() {
+  try {
+    const response = await fetch('/api/black-vault-dashboard');
+    const payload = await safeJson(response);
+    if (!response.ok || !payload) throw new Error('Dashboard endpoint unavailable');
+
+    return {
+      metrics: Array.isArray(payload.metrics) && payload.metrics.length ? payload.metrics : vaultMetrics,
+      offers: normalizeOffers(payload.offers),
+      matrix: normalizeMatrix(payload.matrix),
+      runs: normalizeRuns(payload.runs),
+      reviews: Array.isArray(payload.reviews) ? payload.reviews : [],
+      source: payload.source || 'api',
+    };
+  } catch {
+    return {
+      metrics: vaultMetrics,
+      offers: normalizeOffers([]),
+      matrix: normalizeMatrix([]),
+      runs: warpRuns,
+      reviews: readStorage(STORAGE_KEYS.reviews, []),
+      source: 'local-fallback',
+    };
+  }
+}
+
+export async function saveBlackVaultOffer(offer) {
+  const currentOffers = normalizeOffers([]);
+  const nextOffers = currentOffers.map((item) => item.id === offer.id ? { ...item, ...offer } : item);
+  writeStorage(STORAGE_KEYS.offers, nextOffers);
+
+  try {
+    const response = await fetch('/api/black-vault-offers', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(offer),
+    });
+    const payload = await safeJson(response);
+    if (!response.ok) throw new Error(payload?.error || 'Offer update failed');
+    return { offer: payload?.offer || offer, persisted: payload?.persisted ?? false };
+  } catch {
+    return { offer, persisted: false };
+  }
+}
+
+export async function submitAffiliateMatrixRoute(route) {
+  const currentRows = readStorage(STORAGE_KEYS.matrix, []);
+  const row = {
+    id: route.id || `route-${Date.now()}`,
+    lane: route.lane,
+    source: route.source,
+    cta: route.cta,
+    ctr: route.ctr || '—',
+    epc: route.epc || '—',
+    decision: route.decision || 'Monitor',
+    trackingUrl: route.trackingUrl,
+    metadata: route.metadata || {},
+    createdAt: route.createdAt || new Date().toISOString(),
+  };
+
+  writeStorage(STORAGE_KEYS.matrix, [row, ...currentRows].slice(0, 50));
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new CustomEvent('hydra:black-vault:matrix-updated', { detail: row }));
+  }
+
+  try {
+    const response = await fetch('/api/black-vault-affiliate-matrix', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(row),
+    });
+    const payload = await safeJson(response);
+    if (!response.ok) throw new Error(payload?.error || 'Matrix sync failed');
+    return { row: payload?.row || row, persisted: payload?.persisted ?? false };
+  } catch {
+    return { row, persisted: false };
+  }
+}
+
+export async function fetchBlackVaultReviews() {
+  try {
+    const response = await fetch('/api/black-vault-reviews');
+    const payload = await safeJson(response);
+    if (!response.ok || !payload) throw new Error('Reviews endpoint unavailable');
+    const reviews = Array.isArray(payload.reviews) ? payload.reviews : [];
+    writeStorage(STORAGE_KEYS.reviews, reviews);
+    return reviews;
+  } catch {
+    return readStorage(STORAGE_KEYS.reviews, []);
+  }
+}
+
+export async function updateBlackVaultReviewStatus(reviewId, status) {
+  const currentReviews = readStorage(STORAGE_KEYS.reviews, []);
+  const nextReviews = currentReviews.map((review) => review.id === reviewId ? { ...review, status } : review);
+  writeStorage(STORAGE_KEYS.reviews, nextReviews);
+
+  try {
+    const response = await fetch('/api/black-vault-reviews', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: reviewId, status }),
+    });
+    const payload = await safeJson(response);
+    if (!response.ok) throw new Error(payload?.error || 'Review update failed');
+    return { review: payload?.review || nextReviews.find((review) => review.id === reviewId), persisted: payload?.persisted ?? false };
+  } catch {
+    return { review: nextReviews.find((review) => review.id === reviewId), persisted: false };
+  }
+}

--- a/omega-hydra-app/src/services/blackVaultService.js
+++ b/omega-hydra-app/src/services/blackVaultService.js
@@ -194,7 +194,7 @@ export async function syncBlackVaultWarpRuns() {
       runs: Array.isArray(payload.runs) ? payload.runs : [],
       persisted: Boolean(payload.persisted),
       source: payload.source || 'warp-api',
-      error: null,
+      error: payload.error || null,
     };
   } catch (error) {
     return {
@@ -202,6 +202,37 @@ export async function syncBlackVaultWarpRuns() {
       persisted: false,
       source: 'warp-sync-unavailable',
       error: error?.message || 'Warp sync unavailable',
+    };
+  }
+}
+
+export async function createBlackVaultMetricSnapshot({ metrics, offers, matrix, runs, reviews, metadata = {} }) {
+  try {
+    const response = await fetch('/api/black-vault-metric-snapshots', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        source: 'black-vault-console',
+        metrics,
+        offersCount: offers?.length || 0,
+        matrixCount: matrix?.length || 0,
+        runsCount: runs?.length || 0,
+        reviewsCount: reviews?.length || 0,
+        metadata,
+      }),
+    });
+    const payload = await safeJson(response);
+    if (!response.ok || !payload) throw new Error(payload?.error || 'Metric snapshot unavailable');
+    return {
+      snapshot: payload.snapshot || null,
+      persisted: Boolean(payload.persisted),
+      error: null,
+    };
+  } catch (error) {
+    return {
+      snapshot: null,
+      persisted: false,
+      error: error?.message || 'Metric snapshot unavailable',
     };
   }
 }

--- a/omega-hydra-app/src/services/blackVaultService.js
+++ b/omega-hydra-app/src/services/blackVaultService.js
@@ -180,3 +180,28 @@ export async function updateBlackVaultReviewStatus(reviewId, status) {
     return { review: nextReviews.find((review) => review.id === reviewId), persisted: false };
   }
 }
+
+export async function syncBlackVaultWarpRuns() {
+  try {
+    const response = await fetch('/api/black-vault-warp-sync', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ scope: 'black-vault' }),
+    });
+    const payload = await safeJson(response);
+    if (!response.ok || !payload) throw new Error(payload?.error || 'Warp sync unavailable');
+    return {
+      runs: Array.isArray(payload.runs) ? payload.runs : [],
+      persisted: Boolean(payload.persisted),
+      source: payload.source || 'warp-api',
+      error: null,
+    };
+  } catch (error) {
+    return {
+      runs: [],
+      persisted: false,
+      source: 'warp-sync-unavailable',
+      error: error?.message || 'Warp sync unavailable',
+    };
+  }
+}

--- a/omega-hydra-app/supabase/black-vault-phase-2.sql
+++ b/omega-hydra-app/supabase/black-vault-phase-2.sql
@@ -59,10 +59,24 @@ create table if not exists public.black_vault_reviews (
   updated_at timestamptz not null default now()
 );
 
+create table if not exists public.black_vault_metric_snapshots (
+  id uuid primary key default gen_random_uuid(),
+  source text not null default 'black-vault-console',
+  metric_count integer not null default 0,
+  metrics jsonb not null default '[]'::jsonb,
+  offers_count integer not null default 0,
+  matrix_count integer not null default 0,
+  runs_count integer not null default 0,
+  reviews_count integer not null default 0,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
 create index if not exists idx_black_vault_offers_sort on public.black_vault_offers(sort_order, created_at);
 create index if not exists idx_black_vault_matrix_created on public.black_vault_affiliate_matrix(created_at desc);
 create index if not exists idx_black_vault_runs_updated on public.black_vault_warp_runs(updated_at desc);
 create index if not exists idx_black_vault_reviews_updated on public.black_vault_reviews(updated_at desc);
+create index if not exists idx_black_vault_metric_snapshots_created on public.black_vault_metric_snapshots(created_at desc);
 
 -- Optional seed rows for the console offer ladder.
 insert into public.black_vault_offers (tier, title, price, purpose, sort_order)

--- a/omega-hydra-app/supabase/black-vault-phase-2.sql
+++ b/omega-hydra-app/supabase/black-vault-phase-2.sql
@@ -1,0 +1,97 @@
+-- Black Vault Console Phase 2 persistence schema
+-- Run in Supabase SQL Editor after reviewing access policies.
+
+create extension if not exists pgcrypto;
+
+create table if not exists public.black_vault_offers (
+  id uuid primary key default gen_random_uuid(),
+  tier text not null,
+  title text not null,
+  price text not null,
+  purpose text not null default '',
+  status text not null default 'active',
+  access_tier text not null default 'age-gated',
+  sort_order integer not null default 100,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.black_vault_affiliate_matrix (
+  id uuid primary key default gen_random_uuid(),
+  lane text not null,
+  source text not null default 'unknown',
+  cta text not null default 'Tracked CTA',
+  ctr text,
+  ctr_value numeric,
+  epc text,
+  epc_value numeric,
+  decision text not null default 'Monitor',
+  tracking_url text,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.black_vault_warp_runs (
+  id uuid primary key default gen_random_uuid(),
+  run text not null,
+  task text not null,
+  status text not null default 'Queued',
+  progress integer not null default 0 check (progress >= 0 and progress <= 100),
+  external_ref text,
+  event_source text not null default 'manual',
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.black_vault_reviews (
+  id uuid primary key default gen_random_uuid(),
+  title text not null,
+  type text not null default 'Vault Review',
+  status text not null default 'Needs Review',
+  risk text not null default 'Medium',
+  owner text not null default 'Den Mother',
+  notes text,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists idx_black_vault_offers_sort on public.black_vault_offers(sort_order, created_at);
+create index if not exists idx_black_vault_matrix_created on public.black_vault_affiliate_matrix(created_at desc);
+create index if not exists idx_black_vault_runs_updated on public.black_vault_warp_runs(updated_at desc);
+create index if not exists idx_black_vault_reviews_updated on public.black_vault_reviews(updated_at desc);
+
+-- Optional seed rows for the console offer ladder.
+insert into public.black_vault_offers (tier, title, price, purpose, sort_order)
+select seed.tier, seed.title, seed.price, seed.purpose, seed.sort_order
+from (
+  values
+    ('Entry', 'Velvet Teaser Kit', 'Free', 'Audience warming, list capture, and first-touch curiosity.', 1),
+    ('Starter', 'Black Vault Prompt Starter', '$9', 'Compact prompt pack for persona visuals, article angles, and CTA hooks.', 2),
+    ('Core', 'Velvet Founder Pack', '$27', 'Persona bundle, funnel copy, landing-page blocks, and vault asset templates.', 3),
+    ('Growth', 'Affiliate Matrix Kit', '$97', 'SEO cluster map, review templates, tracking logic, and refresh cadence.', 4),
+    ('Premium', 'Black Vault Console System', '$197', 'Command deck templates, dashboards, governance rails, and workflow packs.', 5)
+) as seed(tier, title, price, purpose, sort_order)
+where not exists (
+  select 1 from public.black_vault_offers existing where existing.title = seed.title
+);
+
+-- Optional seed rows for Den Mother review coverage.
+insert into public.black_vault_reviews (title, type, status, risk, owner)
+select seed.title, seed.type, seed.status, seed.risk, seed.owner
+from (
+  values
+    ('Velrya Public Teaser', 'Character Spotlight', 'Approved', 'Low', 'Den Mother'),
+    ('The Ninth Veil Review Item', 'Vault Review', 'Needs Review', 'Medium', 'Den Mother'),
+    ('Hydra Boundary Check', 'Boundary Audit', 'Blocked', 'High', 'Den Mother')
+) as seed(title, type, status, risk, owner)
+where not exists (
+  select 1 from public.black_vault_reviews existing where existing.title = seed.title
+);
+
+-- NOTE: Current API handlers use server-side SUPABASE_KEY access.
+-- Add row-level security policies only after deciding whether these tables
+-- should ever be queried directly from the browser.


### PR DESCRIPTION
## Summary
Builds the Hydra Black Vault command branch from static UI into a persistence-aware command deck.

## Phase 1 delivered
- New command console UI tab
- Data-backed metrics, command council, offer ladder, affiliate matrix, Warp run center, visualizer stack, and Python head labels
- Sidebar registration and app integration
- Command-deck documentation

## Phase 2 delivered
- API-hydrated console state
- Dashboard aggregation endpoint
- Metric snapshot persistence endpoint
- Editable commercial offer ladder objects
- Affiliate Tracker → Black Vault Matrix submission rail
- Den Mother review queue integrated into Compliance Center
- Warp run intake endpoint
- Warp run CRUD bridge
- Configurable Warp runs sync adapter
- Supabase persistence schema and seeds
- Phase 2 build report

## Core files
- `omega-hydra-app/src/components/tabs/BlackVaultConsole.jsx`
- `omega-hydra-app/src/services/blackVaultService.js`
- `omega-hydra-app/src/components/tabs/AffiliateTracker.jsx`
- `omega-hydra-app/src/components/tabs/ComplianceCenter.jsx`
- `omega-hydra-app/supabase/black-vault-phase-2.sql`
- `docs/black-vault/black-vault-phase-2-build-report.md`

## New API surface
- `/api/black-vault-dashboard`
- `/api/black-vault-offers`
- `/api/black-vault-affiliate-matrix`
- `/api/black-vault-warp-runs`
- `/api/black-vault-run-events`
- `/api/black-vault-warp-sync`
- `/api/black-vault-reviews`
- `/api/black-vault-metric-snapshots`

## Deployment configuration still needed
- Apply the Supabase schema
- Configure `SUPABASE_URL` and `SUPABASE_KEY`
- Optionally configure `WARP_RUNS_ENDPOINT`, `WARP_API_KEY`, and/or `WARP_BEARER_TOKEN` for live run sync

## Current ruling
Phase 2 is build-complete and integration-ready. The next recommended phase is Context Orbit linking across offers, routes, matrix rows, runs, reviews, and metric snapshots.