### PR TITLE
Build Hydra Software Factory Fabric MVP

### DIFF
--- a/omega-hydra-core/README.md
+++ b/omega-hydra-core/README.md
@@ -10,6 +10,12 @@ Build the functioning platform first, then visualize it as a living city.
 Users → Identity → Companion → Mission → Tracking → Product → City Visualization
 ```
 
+For software delivery, Hydra now adds a provider-neutral factory loop:
+
+```text
+Work Request → Plan → Decompose → Dispatch → Build → Test → Security → Docs → Review → Human Approval → Deploy → Observe → Learn
+```
+
 ## MVP Modules
 
 ```text
@@ -17,21 +23,40 @@ omega-hydra-core
 ├── apps
 │   ├── capital-city
 │   ├── guardian-simulator
-│   └── marketplace
+│   ├── marketplace
+│   └── software-factory
 └── packages
     ├── hydra-identity
     ├── hydra-companion
     ├── hydra-labyrinth
     ├── hydra-eyes
-    └── hydra-zeta
+    ├── hydra-zeta
+    └── hydra-software-factory
+```
+
+## Hydra Software Factory Fabric
+
+The software-factory module converts work requests from GitHub, Linear, Jira, Slack, Teams, or the Hydra Console into seven governed worker stages: planner, architect, builder, tester, security reviewer, documenter, and reviewer.
+
+Routing remains provider-neutral. Codex, Claude Code, Warp, and future harnesses are execution providers; Hydra retains the workflow, policy, state, telemetry, governance, and institutional memory.
+
+Run the MVP and smoke test with:
+
+```bash
+npm run factory
+npm run factory:test
 ```
 
 ## Public-Safe Operating Scope
 
-Omega Hydra Core is limited to lawful defensive education, privacy awareness, digital hygiene, ethical decision-making, business automation, community service, readiness training, product delivery, and reflective learning.
+Omega Hydra Core is limited to lawful defensive education, privacy awareness, digital hygiene, ethical decision-making, business automation, community service, readiness training, product delivery, reflective learning, and authorized software engineering.
 
-It does not provide offensive cyber capabilities, weapon instruction, evasion guidance, injury targeting, unauthorized access workflows, or real-world force escalation.
+It does not provide offensive cyber capabilities, weapon instruction, evasion guidance, injury targeting, unauthorized access workflows, malware deployment, or real-world force escalation.
 
 ## MVP-01
 
 Hydra Identity Genesis + Companion Generator + Daily Labyrinth Mission.
+
+## Factory MVP
+
+Hydra Software Factory Fabric + provider/model routing + governance gates + Hydra Eyes telemetry + mock adapter + smoke test.

--- a/omega-hydra-core/apps/software-factory/src/index.js
+++ b/omega-hydra-core/apps/software-factory/src/index.js
@@ -1,0 +1,59 @@
+import { logEvent, getEventSummary, resetEvents } from "../../../packages/hydra-eyes/src/index.js";
+import {
+  createMockHarnessAdapter,
+  runSoftwareFactory,
+  summarizeRoutes
+} from "../../../packages/hydra-software-factory/src/index.js";
+
+async function main() {
+  resetEvents();
+
+  const request = {
+    source: "github",
+    externalRef: "issue-67",
+    repository: "ellbush1420-bushido/hydra-omega-ecosystem-",
+    title: "Hydra Software Factory Fabric MVP",
+    description: "Build a provider-neutral software factory that decomposes software work across specialized agents, routes harnesses and models, enforces governance gates, and records production metrics.",
+    priority: "high",
+    preferredHarness: "generic",
+    targetEnvironment: "development",
+    constraints: [
+      "No external dependency required for MVP",
+      "Production writes require explicit human approval",
+      "Harness and model providers must remain replaceable"
+    ],
+    acceptanceCriteria: [
+      "Intake normalizes requests",
+      "Seven specialized worker stages are generated",
+      "Routing records model and harness choices",
+      "Governance stops unsafe or unapproved actions",
+      "Hydra Eyes records orchestration telemetry"
+    ]
+  };
+
+  const mockHarness = createMockHarnessAdapter({ name: "hydra-mock", retryStages: ["test"] });
+  const run = await runSoftwareFactory(request, {
+    adapters: {
+      generic: mockHarness
+    },
+    maxAttempts: 2,
+    logEvent
+  });
+
+  console.log(JSON.stringify({
+    app: "Hydra Software Factory Fabric MVP",
+    status: run.status,
+    request: run.request,
+    routes: summarizeRoutes(run),
+    metrics: run.metrics,
+    approvals: run.approvals,
+    artifacts: run.artifacts,
+    hydraEyes: getEventSummary(),
+    designRule: "Hydra owns workflow, policy, state, telemetry, and institutional memory. Models and coding harnesses are replaceable execution providers."
+  }, null, 2));
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/omega-hydra-core/package.json
+++ b/omega-hydra-core/package.json
@@ -2,14 +2,16 @@
   "name": "omega-hydra-core",
   "version": "0.1.0",
   "private": true,
-  "description": "Omega Hydra Core MVP foundation: identity, companion, labyrinth, telemetry, marketplace, and capital city shell.",
+  "description": "Omega Hydra Core MVP foundation: identity, companion, labyrinth, telemetry, marketplace, capital city, and software-factory orchestration.",
   "type": "module",
   "scripts": {
     "dev": "node apps/guardian-simulator/src/index.js",
     "genesis": "node packages/hydra-identity/src/demo.js",
     "mission": "node packages/hydra-labyrinth/src/demo.js",
     "marketplace": "node apps/marketplace/src/index.js",
-    "city": "node apps/capital-city/src/index.js"
+    "city": "node apps/capital-city/src/index.js",
+    "factory": "node apps/software-factory/src/index.js",
+    "factory:test": "node packages/hydra-software-factory/test/smoke.mjs"
   },
   "keywords": [
     "omega-hydra",
@@ -17,7 +19,9 @@
     "hydra-identity",
     "hydra-labyrinth",
     "hydra-eyes",
-    "hydra-zeta"
+    "hydra-zeta",
+    "software-factory",
+    "agent-orchestration"
   ],
   "license": "UNLICENSED"
 }

--- a/omega-hydra-core/packages/hydra-software-factory/README.md
+++ b/omega-hydra-core/packages/hydra-software-factory/README.md
@@ -1,0 +1,97 @@
+# Hydra Software Factory Fabric
+
+Provider-neutral agent-fleet orchestration for Omega Hydra Core.
+
+## Purpose
+
+Turn software work requests from GitHub, Linear, Jira, Slack, Teams, or the Hydra Console into a governed execution pipeline:
+
+```text
+Issue → Plan → Decompose → Dispatch → Build → Test → Security → Docs → Review → Human Approval → Deploy → Observe → Learn
+```
+
+The MVP does not hard-code an AI vendor. Hydra owns workflow, policy, state, telemetry, and institutional memory. Codex, Claude Code, Warp, or future coding harnesses attach through adapters.
+
+## Worker Fleet
+
+| Stage | Role |
+|---|---|
+| Plan | Planner |
+| Architecture | Architect |
+| Build | Builder |
+| Test | Tester |
+| Security | Security Reviewer |
+| Docs | Documenter |
+| Review | Reviewer |
+
+## Governance
+
+The runtime evaluates every stage for:
+
+- safe software-engineering scope
+- explicit target workspace for build work
+- scoped secret approval
+- production-write approval
+- passing tests before final review
+- passing security review before final review
+
+Production writes never become autonomous merely because a model or harness can perform them.
+
+## Provider Routing
+
+The built-in registry contains adapter slots for:
+
+- `codex`
+- `claude-code`
+- `generic`
+
+Model routing is scored by quality, latency, cost efficiency, context fit, and tool reliability. The built-in `balanced`, `deep`, and `fast` entries are routing profiles rather than claims about specific vendors.
+
+## Runtime Integration
+
+Pass real harness implementations through `adapters`:
+
+```js
+const run = await runSoftwareFactory(request, {
+  adapters: {
+    codex: codexAdapter,
+    "claude-code": claudeAdapter,
+    generic: fallbackAdapter
+  },
+  logEvent
+});
+```
+
+An adapter only needs an async `execute({ task, request, route, context })` method returning:
+
+```js
+{
+  status: "completed" | "retry" | "failed",
+  retryable: false,
+  message: "...",
+  artifact: {}
+}
+```
+
+## Hydra Eyes Metrics
+
+The factory reports:
+
+- completion rate
+- failure rate
+- retry rate
+- cycle time
+- defect count
+- governance stops
+- per-stage model/harness routes
+
+## Run
+
+From `omega-hydra-core`:
+
+```bash
+node apps/software-factory/src/index.js
+node packages/hydra-software-factory/test/smoke.mjs
+```
+
+No external dependency is required for the MVP smoke path.

--- a/omega-hydra-core/packages/hydra-software-factory/src/index.js
+++ b/omega-hydra-core/packages/hydra-software-factory/src/index.js
@@ -1,0 +1,482 @@
+const SAFE_SCOPE = [
+  "lawful defensive education",
+  "privacy awareness",
+  "digital hygiene",
+  "business automation",
+  "community service",
+  "readiness training",
+  "software engineering",
+  "documentation",
+  "testing",
+  "security review"
+];
+
+export const AGENT_ROLES = Object.freeze([
+  "planner",
+  "architect",
+  "builder",
+  "tester",
+  "security",
+  "documenter",
+  "reviewer"
+]);
+
+export const HARNESS_REGISTRY = Object.freeze({
+  codex: {
+    id: "codex",
+    label: "Codex",
+    capabilities: ["plan", "architecture", "build", "test", "security", "docs", "review"],
+    adapterRequired: true
+  },
+  "claude-code": {
+    id: "claude-code",
+    label: "Claude Code",
+    capabilities: ["plan", "architecture", "build", "test", "security", "docs", "review"],
+    adapterRequired: true
+  },
+  generic: {
+    id: "generic",
+    label: "Generic Harness",
+    capabilities: ["plan", "architecture", "build", "test", "security", "docs", "review"],
+    adapterRequired: false
+  }
+});
+
+export const MODEL_REGISTRY = Object.freeze({
+  balanced: {
+    id: "balanced",
+    label: "Balanced Default",
+    quality: 8,
+    latency: 8,
+    costEfficiency: 8,
+    contextFit: 8,
+    toolReliability: 8
+  },
+  deep: {
+    id: "deep",
+    label: "Deep Reasoning",
+    quality: 10,
+    latency: 5,
+    costEfficiency: 5,
+    contextFit: 10,
+    toolReliability: 8
+  },
+  fast: {
+    id: "fast",
+    label: "Fast Worker",
+    quality: 7,
+    latency: 10,
+    costEfficiency: 9,
+    contextFit: 6,
+    toolReliability: 7
+  }
+});
+
+const STAGE_DEFINITIONS = Object.freeze([
+  { stage: "plan", role: "planner", objective: "Translate the request into explicit goals, constraints, acceptance criteria, and dependencies." },
+  { stage: "architecture", role: "architect", objective: "Design interfaces, boundaries, data flow, state, and implementation sequence." },
+  { stage: "build", role: "builder", objective: "Implement the approved change set in the target workspace." },
+  { stage: "test", role: "tester", objective: "Run deterministic validation, smoke tests, and regression checks." },
+  { stage: "security", role: "security", objective: "Review permissions, secrets, dependencies, unsafe scope, and production-impact risks." },
+  { stage: "docs", role: "documenter", objective: "Update operator documentation, runbooks, and change notes." },
+  { stage: "review", role: "reviewer", objective: "Verify acceptance criteria and prepare the change for human approval." }
+]);
+
+const UNSAFE_SCOPE_PATTERNS = [
+  /credential theft/i,
+  /steal credentials/i,
+  /unauthorized access/i,
+  /deploy malware/i,
+  /ransomware/i,
+  /bypass authentication/i,
+  /disable security controls/i,
+  /evade detection/i
+];
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function uid(prefix) {
+  return `${prefix}_${Date.now()}_${Math.floor(Math.random() * 100000)}`;
+}
+
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value));
+}
+
+function normalizeArray(value) {
+  if (!value) return [];
+  return Array.isArray(value) ? value.filter(Boolean) : [value];
+}
+
+function normalizeSource(value = "hydra-console") {
+  const source = String(value).toLowerCase().trim();
+  const aliases = {
+    github: "github",
+    linear: "linear",
+    jira: "jira",
+    slack: "slack",
+    teams: "teams",
+    "microsoft teams": "teams",
+    hydra: "hydra-console",
+    "hydra console": "hydra-console",
+    "hydra-console": "hydra-console"
+  };
+  return aliases[source] || "hydra-console";
+}
+
+function isUnsafeScope(request) {
+  const haystack = [
+    request.title,
+    request.description,
+    ...request.constraints,
+    ...request.acceptanceCriteria
+  ].join(" ");
+  return UNSAFE_SCOPE_PATTERNS.some((pattern) => pattern.test(haystack));
+}
+
+export function createWorkRequest(input = {}) {
+  const request = {
+    id: input.id || uid("work"),
+    source: normalizeSource(input.source),
+    externalRef: input.externalRef || null,
+    repository: input.repository || null,
+    title: String(input.title || "Untitled software work request").trim(),
+    description: String(input.description || "").trim(),
+    priority: String(input.priority || "normal").toLowerCase(),
+    constraints: normalizeArray(input.constraints),
+    acceptanceCriteria: normalizeArray(input.acceptanceCriteria),
+    preferredHarness: input.preferredHarness || null,
+    preferredModel: input.preferredModel || null,
+    targetEnvironment: input.targetEnvironment || "development",
+    requestedCapabilities: normalizeArray(input.requestedCapabilities),
+    requiresSecrets: Boolean(input.requiresSecrets),
+    requiresProductionWrite: Boolean(input.requiresProductionWrite),
+    humanApproval: Boolean(input.humanApproval),
+    createdAt: input.createdAt || nowIso()
+  };
+
+  request.scopeStatus = isUnsafeScope(request) ? "blocked" : "allowed";
+  return request;
+}
+
+export function decomposeWork(request) {
+  return STAGE_DEFINITIONS.map((definition, index) => ({
+    id: `${request.id}_${String(index + 1).padStart(2, "0")}_${definition.stage}`,
+    workRequestId: request.id,
+    order: index + 1,
+    stage: definition.stage,
+    role: definition.role,
+    objective: definition.objective,
+    status: "queued",
+    attempts: 0,
+    dependencies: index === 0 ? [] : [`${request.id}_${String(index).padStart(2, "0")}_${STAGE_DEFINITIONS[index - 1].stage}`]
+  }));
+}
+
+function modelWeightsForStage(stage) {
+  switch (stage) {
+    case "architecture":
+    case "security":
+    case "review":
+      return { quality: 0.3, latency: 0.1, costEfficiency: 0.1, contextFit: 0.3, toolReliability: 0.2 };
+    case "build":
+    case "test":
+      return { quality: 0.25, latency: 0.15, costEfficiency: 0.15, contextFit: 0.15, toolReliability: 0.3 };
+    default:
+      return { quality: 0.2, latency: 0.2, costEfficiency: 0.2, contextFit: 0.2, toolReliability: 0.2 };
+  }
+}
+
+export function scoreModel(model, stage) {
+  const weights = modelWeightsForStage(stage);
+  return Object.entries(weights).reduce((total, [key, weight]) => total + model[key] * weight, 0);
+}
+
+export function routeModel(task, request, modelRegistry = MODEL_REGISTRY) {
+  if (request.preferredModel && modelRegistry[request.preferredModel]) {
+    return { ...modelRegistry[request.preferredModel], routeReason: "operator preference" };
+  }
+
+  const ranked = Object.values(modelRegistry)
+    .map((model) => ({ model, score: scoreModel(model, task.stage) }))
+    .sort((a, b) => b.score - a.score);
+
+  return { ...ranked[0].model, routeScore: Number(ranked[0].score.toFixed(2)), routeReason: `best weighted fit for ${task.stage}` };
+}
+
+export function routeHarness(task, request, harnessRegistry = HARNESS_REGISTRY) {
+  const preferred = request.preferredHarness && harnessRegistry[request.preferredHarness];
+  if (preferred && preferred.capabilities.includes(task.stage)) {
+    return { ...preferred, routeReason: "operator preference" };
+  }
+
+  const candidate = Object.values(harnessRegistry).find((harness) => harness.capabilities.includes(task.stage));
+  return { ...(candidate || harnessRegistry.generic), routeReason: "capability match" };
+}
+
+export function evaluateGovernance(request, task, context = {}) {
+  const checks = [
+    {
+      id: "scope",
+      status: request.scopeStatus === "allowed" ? "pass" : "block",
+      message: request.scopeStatus === "allowed" ? "Request remains inside approved software-engineering scope." : "Request contains a blocked unsafe capability."
+    },
+    {
+      id: "repository",
+      status: task.stage === "build" && !request.repository ? "review" : "pass",
+      message: task.stage === "build" && !request.repository ? "Build stage needs an explicit target repository or workspace." : "Target workspace requirement satisfied."
+    },
+    {
+      id: "secrets",
+      status: request.requiresSecrets && !context.secretsApproved ? "review" : "pass",
+      message: request.requiresSecrets && !context.secretsApproved ? "Secret access requires explicit approval and scoped credentials." : "No unapproved secret access required."
+    },
+    {
+      id: "production-write",
+      status: request.requiresProductionWrite && !request.humanApproval ? "review" : "pass",
+      message: request.requiresProductionWrite && !request.humanApproval ? "Production writes require explicit human approval." : "Production-write gate satisfied."
+    },
+    {
+      id: "pre-deploy-tests",
+      status: task.stage === "review" && context.testsPassed === false ? "block" : "pass",
+      message: task.stage === "review" && context.testsPassed === false ? "Review blocked because tests failed." : "Test gate does not block this task."
+    },
+    {
+      id: "security-review",
+      status: task.stage === "review" && context.securityPassed === false ? "block" : "pass",
+      message: task.stage === "review" && context.securityPassed === false ? "Review blocked because security review failed." : "Security gate does not block this task."
+    }
+  ];
+
+  const blocked = checks.some((check) => check.status === "block");
+  const needsReview = checks.some((check) => check.status === "review");
+
+  return {
+    decision: blocked ? "block" : needsReview ? "human-review" : "allow",
+    checks
+  };
+}
+
+function createTelemetryCollector(externalLogger) {
+  const events = [];
+  return {
+    emit(type, payload = {}) {
+      const event = {
+        id: uid("factory_evt"),
+        type,
+        payload,
+        createdAt: nowIso()
+      };
+      events.push(event);
+      if (typeof externalLogger === "function") externalLogger(type, payload);
+      return event;
+    },
+    list() {
+      return [...events];
+    }
+  };
+}
+
+export function createMockHarnessAdapter({ name = "mock", failStages = [], retryStages = [] } = {}) {
+  const attemptMap = new Map();
+  return {
+    name,
+    async execute({ task, request, route }) {
+      const attempts = (attemptMap.get(task.id) || 0) + 1;
+      attemptMap.set(task.id, attempts);
+
+      if (retryStages.includes(task.stage) && attempts === 1) {
+        return { status: "retry", retryable: true, message: `${task.stage} requested one retry for smoke validation.` };
+      }
+
+      if (failStages.includes(task.stage)) {
+        return { status: "failed", retryable: false, message: `${task.stage} failed by mock adapter configuration.` };
+      }
+
+      return {
+        status: "completed",
+        retryable: false,
+        message: `${task.role} completed ${task.stage} for ${request.title}.`,
+        artifact: {
+          stage: task.stage,
+          role: task.role,
+          harness: route.harness.id,
+          model: route.model.id
+        }
+      };
+    }
+  };
+}
+
+function getAdapterForRoute(route, adapters) {
+  return adapters[route.harness.id] || adapters.generic || null;
+}
+
+function buildRoute(task, request, options) {
+  return {
+    harness: routeHarness(task, request, options.harnessRegistry || HARNESS_REGISTRY),
+    model: routeModel(task, request, options.modelRegistry || MODEL_REGISTRY)
+  };
+}
+
+function calculateMetrics(run) {
+  const tasks = run.tasks;
+  const completed = tasks.filter((task) => task.status === "completed").length;
+  const failed = tasks.filter((task) => task.status === "failed" || task.status === "blocked").length;
+  const attempts = tasks.reduce((total, task) => total + task.attempts, 0);
+  const retries = Math.max(0, attempts - tasks.filter((task) => task.attempts > 0).length);
+  const started = new Date(run.startedAt).getTime();
+  const ended = new Date(run.completedAt || nowIso()).getTime();
+
+  return {
+    taskCount: tasks.length,
+    completionRate: tasks.length ? Number(((completed / tasks.length) * 100).toFixed(1)) : 0,
+    failureRate: tasks.length ? Number(((failed / tasks.length) * 100).toFixed(1)) : 0,
+    retryRate: attempts ? Number(((retries / attempts) * 100).toFixed(1)) : 0,
+    cycleTimeMs: Math.max(0, ended - started),
+    defectCount: tasks.filter((task) => task.stage === "test" && task.status === "failed").length,
+    governanceStops: tasks.filter((task) => ["blocked", "human-review"].includes(task.status)).length
+  };
+}
+
+export function buildExecutionPlan(input, options = {}) {
+  const request = createWorkRequest(input);
+  const tasks = decomposeWork(request).map((task) => ({
+    ...task,
+    route: buildRoute(task, request, options),
+    governance: evaluateGovernance(request, task, options.context || {})
+  }));
+
+  return {
+    id: uid("factory_plan"),
+    request,
+    tasks,
+    createdAt: nowIso(),
+    designRule: "Hydra owns workflow, policy, state, telemetry, and institutional memory; models and harnesses are replaceable execution providers."
+  };
+}
+
+export async function runSoftwareFactory(input, options = {}) {
+  const telemetry = createTelemetryCollector(options.logEvent);
+  const plan = buildExecutionPlan(input, options);
+  const run = {
+    id: uid("factory_run"),
+    planId: plan.id,
+    request: plan.request,
+    status: "running",
+    startedAt: nowIso(),
+    completedAt: null,
+    tasks: plan.tasks.map((task) => ({ ...task })),
+    approvals: [],
+    artifacts: []
+  };
+
+  telemetry.emit("factory_run_started", { runId: run.id, workRequestId: run.request.id, source: run.request.source });
+
+  let testsPassed;
+  let securityPassed;
+
+  for (const task of run.tasks) {
+    const governance = evaluateGovernance(run.request, task, {
+      ...(options.context || {}),
+      testsPassed,
+      securityPassed
+    });
+    task.governance = governance;
+
+    if (governance.decision === "block") {
+      task.status = "blocked";
+      telemetry.emit("factory_task_blocked", { runId: run.id, taskId: task.id, stage: task.stage, checks: governance.checks });
+      run.status = "blocked";
+      break;
+    }
+
+    if (governance.decision === "human-review") {
+      task.status = "human-review";
+      run.approvals.push({ taskId: task.id, stage: task.stage, requiredAt: nowIso(), checks: governance.checks.filter((check) => check.status === "review") });
+      telemetry.emit("factory_human_review_required", { runId: run.id, taskId: task.id, stage: task.stage });
+      run.status = "awaiting-approval";
+      break;
+    }
+
+    const route = buildRoute(task, run.request, options);
+    task.route = route;
+    telemetry.emit("factory_task_dispatched", {
+      runId: run.id,
+      taskId: task.id,
+      stage: task.stage,
+      role: task.role,
+      harness: route.harness.id,
+      model: route.model.id
+    });
+
+    const adapter = getAdapterForRoute(route, options.adapters || {});
+    if (!adapter) {
+      task.status = "planned";
+      telemetry.emit("factory_adapter_missing", { runId: run.id, taskId: task.id, harness: route.harness.id });
+      run.status = "planned";
+      break;
+    }
+
+    const maxAttempts = clamp(Number(options.maxAttempts || 2), 1, 5);
+    let result;
+    while (task.attempts < maxAttempts) {
+      task.attempts += 1;
+      result = await adapter.execute({ task, request: run.request, route, context: options.context || {} });
+      if (result.status !== "retry") break;
+      telemetry.emit("factory_task_retry", { runId: run.id, taskId: task.id, stage: task.stage, attempt: task.attempts });
+    }
+
+    if (!result || result.status === "retry") {
+      result = { status: "failed", message: "Retry limit exceeded.", retryable: false };
+    }
+
+    task.status = result.status;
+    task.result = result;
+
+    if (result.artifact) run.artifacts.push({ taskId: task.id, ...result.artifact });
+
+    if (task.stage === "test") testsPassed = result.status === "completed";
+    if (task.stage === "security") securityPassed = result.status === "completed";
+
+    telemetry.emit("factory_task_finished", {
+      runId: run.id,
+      taskId: task.id,
+      stage: task.stage,
+      status: task.status,
+      attempts: task.attempts
+    });
+
+    if (task.status !== "completed") {
+      run.status = "failed";
+      break;
+    }
+  }
+
+  if (run.tasks.every((task) => task.status === "completed")) {
+    run.status = run.request.requiresProductionWrite && !run.request.humanApproval ? "awaiting-approval" : "ready-for-approval";
+  }
+
+  run.completedAt = nowIso();
+  run.metrics = calculateMetrics(run);
+  run.telemetry = telemetry.list();
+
+  telemetry.emit("factory_run_finished", { runId: run.id, status: run.status, metrics: run.metrics });
+  run.telemetry = telemetry.list();
+  return run;
+}
+
+export function summarizeRoutes(run) {
+  return run.tasks.map((task) => ({
+    stage: task.stage,
+    role: task.role,
+    status: task.status,
+    harness: task.route?.harness?.id || null,
+    model: task.route?.model?.id || null,
+    attempts: task.attempts
+  }));
+}
+
+export { SAFE_SCOPE };

--- a/omega-hydra-core/packages/hydra-software-factory/test/smoke.mjs
+++ b/omega-hydra-core/packages/hydra-software-factory/test/smoke.mjs
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import {
+  createMockHarnessAdapter,
+  createWorkRequest,
+  buildExecutionPlan,
+  runSoftwareFactory,
+  summarizeRoutes
+} from "../src/index.js";
+
+const request = createWorkRequest({
+  source: "github",
+  repository: "ellbush1420-bushido/hydra-omega-ecosystem-",
+  title: "Build Hydra Software Factory Fabric smoke test",
+  description: "Create a provider-neutral orchestration runtime with governance gates and telemetry.",
+  preferredHarness: "generic",
+  targetEnvironment: "development",
+  acceptanceCriteria: ["plan", "build", "test", "review"]
+});
+
+assert.equal(request.scopeStatus, "allowed");
+assert.equal(request.source, "github");
+
+const plan = buildExecutionPlan(request);
+assert.equal(plan.tasks.length, 7);
+assert.equal(plan.tasks[0].role, "planner");
+assert.equal(plan.tasks[6].role, "reviewer");
+
+const adapter = createMockHarnessAdapter({ retryStages: ["test"] });
+const run = await runSoftwareFactory(request, {
+  adapters: { generic: adapter },
+  maxAttempts: 2
+});
+
+assert.equal(run.status, "ready-for-approval");
+assert.equal(run.metrics.completionRate, 100);
+assert.equal(run.metrics.defectCount, 0);
+assert.equal(run.tasks.find((task) => task.stage === "test").attempts, 2);
+assert.equal(summarizeRoutes(run).length, 7);
+
+const blocked = await runSoftwareFactory({
+  title: "Unsafe request",
+  description: "Deploy malware and evade detection",
+  repository: "demo/repo"
+}, {
+  adapters: { generic: createMockHarnessAdapter() }
+});
+assert.equal(blocked.status, "blocked");
+
+const prodReview = await runSoftwareFactory({
+  title: "Production release",
+  description: "Deploy an approved release",
+  repository: "demo/repo",
+  requiresProductionWrite: true,
+  humanApproval: false
+}, {
+  adapters: { generic: createMockHarnessAdapter() }
+});
+assert.equal(prodReview.status, "awaiting-approval");
+
+console.log("Hydra Software Factory smoke test passed.");


### PR DESCRIPTION
Closes #67

## What this adds
- provider-neutral software-factory orchestration runtime
- normalized intake for GitHub / Linear / Jira / Slack / Teams / Hydra Console
- seven specialized worker stages
- harness routing for Codex, Claude Code, and generic adapters
- model routing using quality, latency, cost efficiency, context fit, and tool reliability
- governance gates for unsafe scope, secrets, repository targeting, tests, security review, and production writes
- retry handling and mock adapter
- Hydra Eyes telemetry bridge
- runnable demo app
- smoke tests
- npm scripts and core documentation

## Validation
Locally exercised the exact module logic with Node:
- smoke test passed
- demo completed all seven stages
- test stage retry path completed on second attempt
- unsafe scope blocked
- unapproved production write stopped at human review

## Architectural rule
Hydra owns workflow, policy, state, telemetry, governance, and institutional memory. Models/harnesses remain replaceable execution providers.
