### PR TITLE
Add Hydra Source Intel, Cloud Ops, and Continuity

### DIFF
--- a/omega-hydra-core/README.md
+++ b/omega-hydra-core/README.md
@@ -10,7 +10,7 @@ Build the functioning platform first, then visualize it as a living city.
 Users → Identity → Companion → Mission → Tracking → Product → City Visualization
 ```
 
-For software delivery, Hydra now adds a provider-neutral factory loop:
+For software delivery, Hydra uses a provider-neutral factory loop:
 
 ```text
 Work Request → Plan → Decompose → Dispatch → Build → Test → Security → Docs → Review → Human Approval → Deploy → Observe → Learn
@@ -24,14 +24,18 @@ omega-hydra-core
 │   ├── capital-city
 │   ├── guardian-simulator
 │   ├── marketplace
-│   └── software-factory
+│   ├── software-factory
+│   └── agent-extensions
 └── packages
     ├── hydra-identity
     ├── hydra-companion
     ├── hydra-labyrinth
     ├── hydra-eyes
     ├── hydra-zeta
-    └── hydra-software-factory
+    ├── hydra-software-factory
+    ├── hydra-source-intel
+    ├── hydra-cloud-ops
+    └── hydra-continuity
 ```
 
 ## Hydra Software Factory Fabric
@@ -40,23 +44,51 @@ The software-factory module converts work requests from GitHub, Linear, Jira, Sl
 
 Routing remains provider-neutral. Codex, Claude Code, Warp, and future harnesses are execution providers; Hydra retains the workflow, policy, state, telemetry, governance, and institutional memory.
 
-Run the MVP and smoke test with:
+## Hydra Source Intel
+
+Hydra's proprietary social/public-source ingestion layer. It classifies X, LinkedIn, Instagram, TikTok, Reddit, Hacker News, and general web sources; routes requests through user-supplied snapshots, official APIs, permitted public-web adapters, or authorized archives; extracts reusable signals; and feeds them into Hydra workflows.
+
+Hydra Source Intel intentionally does **not** bypass logins, paywalls, CAPTCHAs, authentication, or technical access controls. When a compliant adapter is unavailable, the request stops for authorization or user-supplied content.
+
+## Hydra Cloud Ops
+
+Hydra's provider-neutral authorized database/infrastructure operations layer inspired by modern cloud CLIs/MCP tools. The MVP plans and governs Timescale-compatible database tasks including health checks, hypertable inspection/creation, and continuous aggregate inspection/creation.
+
+Cloud writes require explicit approval and the default mode is dry-run. Credentials are never invented or embedded.
+
+## Hydra Continuity
+
+Hydra's checkpoint-and-resume runtime for long-running agent workflows. It persists completed/pending steps and state, pauses cleanly when a provider limit or dependency stops execution, and resumes only after an explicit capacity-reset, dependency-ready, or operator-approval signal.
+
+Hydra Continuity does not evade provider quotas or usage limits; it resumes after the limiting condition has legitimately cleared and re-runs governance before privileged execution.
+
+## Commands
 
 ```bash
 npm run factory
 npm run factory:test
+npm run extensions
+npm run extensions:test
+```
+
+Individual extension tests:
+
+```bash
+npm run source:test
+npm run cloud:test
+npm run continuity:test
 ```
 
 ## Public-Safe Operating Scope
 
-Omega Hydra Core is limited to lawful defensive education, privacy awareness, digital hygiene, ethical decision-making, business automation, community service, readiness training, product delivery, reflective learning, and authorized software engineering.
+Omega Hydra Core is limited to lawful defensive education, privacy awareness, digital hygiene, ethical decision-making, business automation, community service, readiness training, product delivery, reflective learning, authorized software engineering, public-source research, and authorized infrastructure administration.
 
-It does not provide offensive cyber capabilities, weapon instruction, evasion guidance, injury targeting, unauthorized access workflows, malware deployment, or real-world force escalation.
+It does not provide offensive cyber capabilities, weapon instruction, evasion guidance, injury targeting, unauthorized access workflows, malware deployment, credential theft, access-control bypass, or real-world force escalation.
 
-## MVP-01
+## Current Executable Layers
 
-Hydra Identity Genesis + Companion Generator + Daily Labyrinth Mission.
-
-## Factory MVP
-
-Hydra Software Factory Fabric + provider/model routing + governance gates + Hydra Eyes telemetry + mock adapter + smoke test.
+- Hydra Identity Genesis + Companion Generator + Daily Labyrinth Mission
+- Hydra Software Factory Fabric + provider/model routing + governance + telemetry
+- Hydra Source Intel + compliant social/public-source ingestion
+- Hydra Cloud Ops + authorized Timescale-compatible database task planning/execution adapters
+- Hydra Continuity + checkpoint/resume control for long-running agent workflows

--- a/omega-hydra-core/apps/agent-extensions/src/index.js
+++ b/omega-hydra-core/apps/agent-extensions/src/index.js
@@ -1,0 +1,38 @@
+import { retrievePublicSource } from "../../../packages/hydra-source-intel/src/index.js";
+import { runCloudTask } from "../../../packages/hydra-cloud-ops/src/index.js";
+import { createCheckpoint, buildResumePlan } from "../../../packages/hydra-continuity/src/index.js";
+import { logEvent, getEventSummary } from "../../../packages/hydra-eyes/src/index.js";
+
+async function runDemo() {
+  const source = await retrievePublicSource({
+    platform: "hackernews",
+    url: "https://news.ycombinator.com/item?id=demo",
+    title: "Hydra Source Intel Demo",
+    suppliedSnapshot: "A public discussion about AI agents, software automation, model routing, security, and developer workflows."
+  });
+  logEvent("source_intel_completed", { status: source.status, platform: source.request.platform, adapter: source.route.adapter });
+
+  const cloud = await runCloudTask({ action: "list-hypertables", database: "hydra_demo", dryRun: true });
+  logEvent("cloud_ops_planned", { status: cloud.status, action: cloud.task.action });
+
+  const checkpoint = createCheckpoint({
+    workflowId: "factory-demo",
+    stage: "test",
+    completedSteps: ["plan", "architect", "build"],
+    pendingSteps: ["test", "security", "review"],
+    reason: "provider-limit"
+  });
+  const continuity = buildResumePlan(checkpoint, { limitReset: true });
+  logEvent("continuity_evaluated", { resume: continuity.decision.resume, nextStep: continuity.nextStep });
+
+  return {
+    app: "Omega Hydra Agent Extensions",
+    modules: ["Hydra Source Intel", "Hydra Cloud Ops", "Hydra Continuity"],
+    source,
+    cloud,
+    continuity,
+    telemetry: getEventSummary()
+  };
+}
+
+console.log(JSON.stringify(await runDemo(), null, 2));

--- a/omega-hydra-core/package.json
+++ b/omega-hydra-core/package.json
@@ -1,8 +1,8 @@
 {
   "name": "omega-hydra-core",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
-  "description": "Omega Hydra Core MVP foundation: identity, companion, labyrinth, telemetry, marketplace, capital city, and software-factory orchestration.",
+  "description": "Omega Hydra Core MVP foundation: identity, companion, labyrinth, telemetry, marketplace, software-factory orchestration, source intelligence, cloud operations, and workflow continuity.",
   "type": "module",
   "scripts": {
     "dev": "node apps/guardian-simulator/src/index.js",
@@ -11,7 +11,12 @@
     "marketplace": "node apps/marketplace/src/index.js",
     "city": "node apps/capital-city/src/index.js",
     "factory": "node apps/software-factory/src/index.js",
-    "factory:test": "node packages/hydra-software-factory/test/smoke.mjs"
+    "factory:test": "node packages/hydra-software-factory/test/smoke.mjs",
+    "extensions": "node apps/agent-extensions/src/index.js",
+    "source:test": "node packages/hydra-source-intel/test/smoke.mjs",
+    "cloud:test": "node packages/hydra-cloud-ops/test/smoke.mjs",
+    "continuity:test": "node packages/hydra-continuity/test/smoke.mjs",
+    "extensions:test": "npm run source:test && npm run cloud:test && npm run continuity:test"
   },
   "keywords": [
     "omega-hydra",
@@ -21,7 +26,10 @@
     "hydra-eyes",
     "hydra-zeta",
     "software-factory",
-    "agent-orchestration"
+    "agent-orchestration",
+    "source-intelligence",
+    "database-operations",
+    "workflow-continuity"
   ],
   "license": "UNLICENSED"
 }

--- a/omega-hydra-core/packages/hydra-cloud-ops/src/index.js
+++ b/omega-hydra-core/packages/hydra-cloud-ops/src/index.js
@@ -1,0 +1,90 @@
+const SAFE_ACTIONS = new Set([
+  "list-services",
+  "inspect-database",
+  "list-hypertables",
+  "list-continuous-aggregates",
+  "plan-hypertable",
+  "plan-continuous-aggregate",
+  "health-check"
+]);
+
+const WRITE_ACTIONS = new Set([
+  "create-hypertable",
+  "create-continuous-aggregate",
+  "alter-retention-policy"
+]);
+
+export function normalizeCloudTask(input = {}) {
+  const action = input.action || "health-check";
+  return {
+    id: input.id || `cloud_${Date.now()}_${Math.floor(Math.random() * 10000)}`,
+    provider: input.provider || "timescale-compatible",
+    action,
+    database: input.database || null,
+    table: input.table || null,
+    timeColumn: input.timeColumn || "time",
+    bucket: input.bucket || "1 hour",
+    query: input.query || null,
+    dryRun: input.dryRun !== false,
+    approved: input.approved === true,
+    requestedAt: new Date().toISOString()
+  };
+}
+
+export function evaluateCloudPolicy(task = {}) {
+  if (!SAFE_ACTIONS.has(task.action) && !WRITE_ACTIONS.has(task.action)) {
+    return { allowed: false, reason: "Unsupported or destructive cloud action requires manual review." };
+  }
+  if (WRITE_ACTIONS.has(task.action) && !task.approved) {
+    return { allowed: false, reason: "Cloud write requires explicit approval." };
+  }
+  if (task.action === "create-hypertable" && (!task.table || !task.timeColumn)) {
+    return { allowed: false, reason: "Hypertable creation requires table and time column." };
+  }
+  return { allowed: true, reason: task.dryRun ? "Approved for planning/dry-run." : "Approved for authorized execution." };
+}
+
+export function buildSqlPlan(task = {}) {
+  switch (task.action) {
+    case "list-hypertables":
+      return "SELECT * FROM timescaledb_information.hypertables ORDER BY hypertable_schema, hypertable_name;";
+    case "list-continuous-aggregates":
+      return "SELECT * FROM timescaledb_information.continuous_aggregates ORDER BY view_schema, view_name;";
+    case "create-hypertable":
+      return `SELECT create_hypertable('${task.table}', by_range('${task.timeColumn}'), if_not_exists => TRUE);`;
+    case "create-continuous-aggregate":
+      if (!task.query) throw new Error("Continuous aggregate requires a SELECT query.");
+      return task.query;
+    case "health-check":
+      return "SELECT now() AS checked_at, current_database() AS database, version() AS version;";
+    default:
+      return null;
+  }
+}
+
+export async function runCloudTask(input = {}, adapter = null) {
+  const task = normalizeCloudTask(input);
+  const policy = evaluateCloudPolicy(task);
+  if (!policy.allowed) return { status: "blocked", task, policy };
+
+  const sql = buildSqlPlan(task);
+  if (task.dryRun || typeof adapter !== "function") {
+    return {
+      status: task.dryRun ? "planned" : "adapter-required",
+      task,
+      policy,
+      sql,
+      note: "Hydra Cloud Ops never invents credentials and executes only against explicitly authorized infrastructure."
+    };
+  }
+
+  const result = await adapter({ task, sql });
+  return { status: "complete", task, policy, sql, result };
+}
+
+export const HYDRA_CLOUD_OPS_CAPABILITIES = {
+  observability: [...SAFE_ACTIONS],
+  writes: [...WRITE_ACTIONS],
+  defaultMode: "dry-run",
+  authorizationRequired: true
+};

--- a/omega-hydra-core/packages/hydra-cloud-ops/test/smoke.mjs
+++ b/omega-hydra-core/packages/hydra-cloud-ops/test/smoke.mjs
@@ -1,0 +1,11 @@
+import assert from "node:assert/strict";
+import { runCloudTask } from "../src/index.js";
+
+const inspect = await runCloudTask({ action: "list-hypertables", database: "demo", dryRun: true });
+assert.equal(inspect.status, "planned");
+assert.match(inspect.sql, /timescaledb_information\.hypertables/);
+
+const blocked = await runCloudTask({ action: "create-hypertable", table: "events", timeColumn: "created_at", dryRun: false, approved: false });
+assert.equal(blocked.status, "blocked");
+
+console.log("Hydra Cloud Ops smoke test passed");

--- a/omega-hydra-core/packages/hydra-continuity/src/index.js
+++ b/omega-hydra-core/packages/hydra-continuity/src/index.js
@@ -1,0 +1,57 @@
+export function createCheckpoint(input = {}) {
+  return {
+    id: input.id || `checkpoint_${Date.now()}_${Math.floor(Math.random() * 10000)}`,
+    workflowId: input.workflowId || "unknown-workflow",
+    stage: input.stage || "unknown-stage",
+    completedSteps: [...(input.completedSteps || [])],
+    pendingSteps: [...(input.pendingSteps || [])],
+    state: input.state || {},
+    reason: input.reason || "operator-pause",
+    resumable: input.resumable !== false,
+    createdAt: new Date().toISOString()
+  };
+}
+
+export function evaluateResume(checkpoint = {}, signal = {}) {
+  if (!checkpoint.resumable) return { resume: false, reason: "Checkpoint is not resumable." };
+  if (signal.cancelled) return { resume: false, reason: "Workflow was cancelled." };
+  if (signal.policyBlocked) return { resume: false, reason: "Governance block requires review." };
+  if (signal.limitReset === true || signal.operatorApproved === true || signal.dependencyReady === true) {
+    return { resume: true, reason: signal.limitReset ? "Execution capacity available again." : "Resume condition satisfied." };
+  }
+  return { resume: false, reason: "Waiting for an explicit resume condition." };
+}
+
+export function buildResumePlan(checkpoint = {}, signal = {}) {
+  const decision = evaluateResume(checkpoint, signal);
+  return {
+    workflowId: checkpoint.workflowId,
+    checkpointId: checkpoint.id,
+    decision,
+    nextStep: decision.resume ? checkpoint.pendingSteps[0] || null : null,
+    remainingSteps: decision.resume ? [...checkpoint.pendingSteps] : [],
+    restoreState: decision.resume ? checkpoint.state : null,
+    rules: [
+      "Do not bypass provider quotas or usage limits.",
+      "Resume only after capacity, approval, or dependency readiness is explicitly signaled.",
+      "Persist state before pausing so work can continue without repeating completed steps.",
+      "Re-run governance checks before deployment or privileged writes."
+    ]
+  };
+}
+
+export function createContinuityController({ persist = async () => {}, load = async () => null } = {}) {
+  return {
+    async pause(input) {
+      const checkpoint = createCheckpoint(input);
+      await persist(checkpoint);
+      return checkpoint;
+    },
+    async resume(checkpointId, signal = {}) {
+      const checkpoint = await load(checkpointId);
+      if (!checkpoint) return { status: "missing-checkpoint", checkpointId };
+      const plan = buildResumePlan(checkpoint, signal);
+      return { status: plan.decision.resume ? "ready" : "waiting", ...plan };
+    }
+  };
+}

--- a/omega-hydra-core/packages/hydra-continuity/test/smoke.mjs
+++ b/omega-hydra-core/packages/hydra-continuity/test/smoke.mjs
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import { createCheckpoint, buildResumePlan } from "../src/index.js";
+
+const checkpoint = createCheckpoint({
+  workflowId: "demo",
+  stage: "build",
+  completedSteps: ["plan"],
+  pendingSteps: ["build", "test"]
+});
+const waiting = buildResumePlan(checkpoint, {});
+assert.equal(waiting.decision.resume, false);
+const ready = buildResumePlan(checkpoint, { limitReset: true });
+assert.equal(ready.decision.resume, true);
+assert.equal(ready.nextStep, "build");
+
+console.log("Hydra Continuity smoke test passed");

--- a/omega-hydra-core/packages/hydra-source-intel/src/index.js
+++ b/omega-hydra-core/packages/hydra-source-intel/src/index.js
@@ -1,0 +1,92 @@
+const SUPPORTED = new Set(["x", "linkedin", "instagram", "tiktok", "reddit", "hackernews", "web"]);
+
+const POLICY = {
+  publicOnly: true,
+  respectAuthentication: true,
+  respectAccessControls: true,
+  requireOfficialApiWhenNeeded: true,
+  noLoginBypass: true,
+  noPaywallBypass: true,
+  noCaptchaBypass: true,
+  noCredentialReuse: true
+};
+
+export function classifySocialUrl(url = "") {
+  const value = String(url).toLowerCase();
+  if (value.includes("x.com/") || value.includes("twitter.com/")) return "x";
+  if (value.includes("linkedin.com/")) return "linkedin";
+  if (value.includes("instagram.com/")) return "instagram";
+  if (value.includes("tiktok.com/")) return "tiktok";
+  if (value.includes("reddit.com/")) return "reddit";
+  if (value.includes("news.ycombinator.com/")) return "hackernews";
+  return "web";
+}
+
+export function normalizeSourceRequest(input = {}) {
+  const platform = input.platform || classifySocialUrl(input.url);
+  if (!SUPPORTED.has(platform)) throw new Error(`Unsupported source platform: ${platform}`);
+  return {
+    id: input.id || `src_${Date.now()}_${Math.floor(Math.random() * 10000)}`,
+    platform,
+    url: input.url || null,
+    query: input.query || null,
+    mode: input.mode || "public",
+    suppliedSnapshot: input.suppliedSnapshot || null,
+    requestedAt: new Date().toISOString()
+  };
+}
+
+export function chooseSourceAdapter(request, capabilities = {}) {
+  if (request.suppliedSnapshot) return { adapter: "user-supplied-snapshot", reason: "User supplied the content directly." };
+
+  const officialKey = `${request.platform}Api`;
+  if (capabilities[officialKey]) return { adapter: "official-api", reason: `Authorized ${request.platform} API available.` };
+
+  if (request.platform === "reddit" && capabilities.publicWeb) return { adapter: "public-web", reason: "Public page retrieval allowed." };
+  if (request.platform === "hackernews" && capabilities.publicWeb) return { adapter: "public-web", reason: "Public page retrieval allowed." };
+  if (request.platform === "web" && capabilities.publicWeb) return { adapter: "public-web", reason: "Public web retrieval allowed." };
+  if (capabilities.authorizedArchive) return { adapter: "authorized-archive", reason: "Use an archive only where access and terms permit it." };
+
+  return {
+    adapter: "needs-authorization",
+    reason: "No compliant public or authorized adapter is available. Hydra will not bypass login, paywall, CAPTCHA, or access controls."
+  };
+}
+
+export function extractSignals(document = {}) {
+  const text = String(document.text || document.content || "").replace(/\s+/g, " ").trim();
+  const sentences = text.split(/(?<=[.!?])\s+/).filter(Boolean);
+  const tags = ["agent", "ai", "model", "workflow", "security", "privacy", "automation", "product", "developer", "software"]
+    .filter((tag) => text.toLowerCase().includes(tag));
+  return {
+    title: document.title || "Untitled source",
+    summary: sentences.slice(0, 3).join(" ").slice(0, 800),
+    keySignals: tags,
+    length: text.length,
+    sourceUrl: document.url || null
+  };
+}
+
+export async function retrievePublicSource(input = {}, capabilities = {}, adapters = {}) {
+  const request = normalizeSourceRequest(input);
+  const route = chooseSourceAdapter(request, capabilities);
+
+  if (route.adapter === "needs-authorization") {
+    return { status: "blocked", request, route, policy: POLICY };
+  }
+
+  if (route.adapter === "user-supplied-snapshot") {
+    const document = { title: input.title, text: request.suppliedSnapshot, url: request.url };
+    return { status: "complete", request, route, document, signals: extractSignals(document), policy: POLICY };
+  }
+
+  const adapter = adapters[route.adapter];
+  if (typeof adapter !== "function") {
+    return { status: "adapter-required", request, route, policy: POLICY };
+  }
+
+  const document = await adapter(request);
+  return { status: "complete", request, route, document, signals: extractSignals(document), policy: POLICY };
+}
+
+export { POLICY as SOURCE_INTEL_POLICY };

--- a/omega-hydra-core/packages/hydra-source-intel/test/smoke.mjs
+++ b/omega-hydra-core/packages/hydra-source-intel/test/smoke.mjs
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import { retrievePublicSource } from "../src/index.js";
+
+const direct = await retrievePublicSource({
+  platform: "x",
+  url: "https://x.com/example/status/1",
+  suppliedSnapshot: "AI agent workflow automation and software security discussion."
+});
+assert.equal(direct.status, "complete");
+assert.equal(direct.route.adapter, "user-supplied-snapshot");
+
+const blocked = await retrievePublicSource({ platform: "instagram", url: "https://instagram.com/p/example" }, {});
+assert.equal(blocked.status, "blocked");
+assert.equal(blocked.policy.noLoginBypass, true);
+
+console.log("Hydra Source Intel smoke test passed");


### PR DESCRIPTION
Closes #69

Adds three proprietary Omega Hydra Core extensions:

- **Hydra Source Intel** — public/social source classification, compliant adapter routing, signal extraction, and hard stops on login/paywall/CAPTCHA/access-control bypass.
- **Hydra Cloud Ops** — authorized Timescale-compatible database task planning/execution adapters for health checks, hypertables, and continuous aggregates, with dry-run default and approval-required writes.
- **Hydra Continuity** — checkpoint/resume control for long-running agent workflows, resuming only after legitimate capacity reset, dependency readiness, or operator approval.

Also adds:
- `apps/agent-extensions` integration demo
- Hydra Eyes telemetry events
- smoke tests for all three modules
- `npm run extensions` and `npm run extensions:test`
- Omega Hydra Core README and version update

Design rule: Hydra owns routing, governance, state, telemetry, and institutional memory; external providers remain replaceable adapters.